### PR TITLE
Fix heading for setting of `login`

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -194,7 +194,7 @@ This is the Ribose API.
                 + `thumb_height`                 (number)
 
 
-### Set `login` [PUT /people/users/{user_id}]
+### Set login [PUT /people/users/{user_id}]
 
 + Parameters
     + `user_id` (uuid) - UUID of the current User

--- a/apiary.apib
+++ b/apiary.apib
@@ -194,7 +194,7 @@ This is the Ribose API.
                 + `thumb_height`                 (number)
 
 
-#### Set `login` [PUT /people/users/{user_id}]
+### Set `login` [PUT /people/users/{user_id}]
 
 + Parameters
     + `user_id` (uuid) - UUID of the current User

--- a/apiary.apib
+++ b/apiary.apib
@@ -194,6 +194,24 @@ This is the Ribose API.
                 + `thumb_height`                 (number)
 
 
+#### Set `login` [PUT /people/users/{user_id}]
+
++ Parameters
+    + `user_id` (uuid) - UUID of the current User
+
++ Request (application/json)
+
+    + Attributes (object)
+        + `login` (string) - must be between 7 to 40 characters long
+
++ Response 403 (application/json)
+
++ Response 422 (application/json)
+
++ Response 200 (application/json)
+
+    + Attributes (object)
+
 ## Group Calendar
 
 ### Calendars [/calendar/calendar]

--- a/sections/profile.apib
+++ b/sections/profile.apib
@@ -24,3 +24,21 @@
 
     + Attributes (object)
 :[](profile/profile.apib)
+
+#### Set `login` [PUT /people/users/{user_id}]
+
++ Parameters
+    + `user_id` (uuid) - UUID of the current User
+
++ Request (application/json)
+
+    + Attributes (object)
+        + `login` (string) - must be between 7 to 40 characters long
+
++ Response 403 (application/json)
+
++ Response 422 (application/json)
+
++ Response 200 (application/json)
+
+    + Attributes (object)

--- a/sections/profile.apib
+++ b/sections/profile.apib
@@ -25,7 +25,7 @@
     + Attributes (object)
 :[](profile/profile.apib)
 
-#### Set `login` [PUT /people/users/{user_id}]
+### Set login [PUT /people/users/{user_id}]
 
 + Parameters
     + `user_id` (uuid) - UUID of the current User


### PR DESCRIPTION
Apiary b0rks on backticks inside headings.