### PR TITLE
Fix up login-update data type mistake

### DIFF
--- a/sections/profile.apib
+++ b/sections/profile.apib
@@ -33,7 +33,8 @@
 + Request (application/json)
 
     + Attributes (object)
-        + `login` (string) - must be between 7 to 40 characters long
+        + `user` (object)
+            + `login`: mynewusername (string) - must be between 7 to 40 characters long
 
 + Response 403 (application/json)
 


### PR DESCRIPTION
Data type was wrong --- `user` was omitted.  Adding it back.

This PR also adds an example `login` value.

Example values are added towards the eventual goal of being able to use the Apiary mock server in the Ruby client tests.