### PR TITLE
Fix general structure

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -128,6 +128,54 @@ This is the Ribose API.
 * `name` (string) - Space name
 * `members_count` (number) - how many members it contains
 
+### File (object)
+
++ `allow_create` (boolean) - the permission of User to create a file
++ `allow_delete` (boolean) - the permission of User to delete a file
++ `allow_download` (boolean) - the permission of User to download a file
++ `allow_edit` (boolean) - the permission of User to edit a file
++ `allow_update` (boolean) - the permission of User to update a file
++ `author` (string) - the name of User
++ `content_size` (number) - the content size of the file
++ `content_type` (string) - the content type of the file
++ `created_at` (DatetimeString) - of when the file created
++ `current_version_id` (id) - the current version id of the version of the file
++ `description` (string) - the description of the file
++ `id` (id) - the id of the file
++ `name` (string) - the name of the file
++ `tag_list` (array[string]) - the list of tags
++ `updated_at` (DatetimeString) - of when the file updated
++ `version` (number) - the version number of the array of the file versions
++ `versions` (array[object]) - the array of the file version objects with attributes:
+    + (object)
+        + `author` (string) - the name of the author
+        + `content_size` (number) - the content size of the file version
+        + `content_type` (string) - the content type of the file version
+        + `created_at` (DatetimeString) of when the file version created
+        + `current_version_id` (id) - the current version id of the version of the file
+        + `description` (string) - the description of the file version
+        + `file_info_id` (id) - the version id of the version of the file
+        + `icon_path` (string) - the path of the thumbnail of the file version
+        + `name` (string) - the name of the file version
+        + `position` (number) - the number of the order in position of the file version
+        + `updated_at` (DatetimeString) - of when the file version updated
+        + `version` (number) - the version number of the file version
+
+### FileVersion (object)
+
++ `author` (string) - name of the author
++ `content_size` (number) - content size of the file version
++ `content_type` (string) - content type of the file version
++ `created_at` (DatetimeString) - date of when the file version was created
++ `current_version_id` (id) - current version ID of the version of the file
++ `description` (string) - description of the file version
++ `file_info_id` (id) - version ID of the version of the file
++ `icon_path` (string) - path of the thumbnail of the file version
++ `name` (string) - name of the file version
++ `position` (number) - number of the order in position of the file version
++ `updated_at` (DatetimeString) - when the file version was updated
++ `version` (number) - version number of the file
+
 [comment]: <> (REFERENCE section)
 
 ## Group General
@@ -176,15 +224,12 @@ This is the Ribose API.
 ### Request settings [GET /settings]
 
 + Request (application/json)
-    + Attributes (object)
 
 + Response 200 (application/json)
-    + Attributes (object)
 
 ### Request spaces [GET /spaces]
 
 + Request (application/json)
-    + Attributes (object)
 
 + Response 200 (application/json)
     + Attributes (object)
@@ -221,7 +266,6 @@ This is the Ribose API.
 ### User connections [GET /people/connections]
 
 + Request (application/json)
-    + Attributes (object)
 
 + Response 200 (application/json)
     + Attributes (object)
@@ -2194,38 +2238,52 @@ This is the Ribose API.
 
 ## Group File
 
-### Upload a file [POST /spaces/:id/file/files/upload]
+### Upload a file [POST /spaces/{space_id}/file/files/upload]
+
++ Parameters
+    + `space_id` (uuid) - UUID of space
 
 + Request (application/json)
     + Attributes (object)
-        + `id` (required, string) - UUID of space
-        + `file_info[attachment][]` (required, array) - array of files to be uploaded
-        + `file_info[tag_list]` (required, string) - list of tags separated by commas
-        + `file_info[description]` (optional, string) - description of the file
+        + `file_info` (object)
+            + `attachment` (required, array) - array of files to be uploaded
+            + `description`: This is an important file (optional, string) - description of the file
+            + `tag_list`: tag1,tag2 (optional, string) - list of tags separated by commas
 
 + Response 200 (application/json)
     + Attributes (object)
-        + `attachment` (object) - the file attributes
+        + `attachment` (File)
 
 + Response 422 (application/json)
     + Attributes (object)
         + `attachment_errors` (string) - the error message
 
-### List files [GET /spaces/:id/file/files]
+### List files [GET /spaces/{space_id}/file/files]
+
++ Parameters
+    + `space_id` (uuid) - UUID of space
 
 + Request (application/json)
     + Attributes (object)
-        + `id` (required, string) - UUID of space
-        + `order_by` (optional, string) - sort order of files, `name, size, date, author, file_type`, default `date`
-        + `direction` (optional, string) - sort direction of files, `asc, desc`, default desc
-        + `start` (optional, number) - starting index of file collection, default 0
-        + `length` (optional, number) - maximum size of collection, default 100
+        + `order_by`: date (optional, enum[string]) - sort order of files
+            + Members
+                + name
+                + size
+                + date
+                + author
+                + file_type
+        + `direction`: desc (optional, enum[string]) - sort direction of files
+            + Members
+                + asc
+                + desc
+        + `start`: 0 (optional, number) - starting index of file collection, default: 0
+        + `length`: 100 (optional, number) - maximum size of collection, default: 100
 
 + Response 200 (application/json)
     + Attributes (object)
         + `total` (number) - total number of files
         + `indices` (object) - hash of index-file_id
-        + `objects` (array) - array of file attributes
+        + `objects` (array[File]) - array of file attributes
         + `tags` (object) - hash of tags
             + `all_tags` (array) - the array of all tags in space
             + `related_tags` (array) - array of tags related to the current file
@@ -2233,9 +2291,10 @@ This is the Ribose API.
         + `recent_activity` (array) - array of recent activities of files
             + `date` (string) - the date of the activities in format `%A, %B %d, %Y`
             + `links` (array) - the array of recent updated files inside the grouped date
-                + `id` (number) - the ID of the file
-                + `name` (string) - the name of the file
-                + `path` (string) - the relative path of the link to the file
+                + (object)
+                    + `id` (number) - the ID of the file
+                    + `name` (string) - the name of the file
+                    + `path` (string) - the relative path of the link to the file
         + `permissions` (object) - the hash of the permissions of the user
             + `allow_create` (boolean) - the permission of the user to create a file
             + `allow_delete` (boolean) - the permission of the user to delete a file
@@ -2244,49 +2303,74 @@ This is the Ribose API.
             + `allow_mass_actions` (boolean) - the permission of the user to perform mass actions on files
 
 
-### Show a file [GET /spaces/:id/file/files/:file_id]
+### File [/spaces/{space_id}/file/files/{file_id}]
+
++ Parameters
+    + `space_id` (uuid) - UUID of space
+    + `file_id` (id) - ID of file
+
+#### Show a file [GET]
+
++ Request (text/html)
+
++ Response 200
+
+    - Redirects to download link of the file
+    + Body
+
++ Request (application/json)
+
++ Response 200 (application/json)
+
+    - This returns a hash of file indices and an array of objects of files
+
+    + Attributes (object)
+        + `file` (File)
+
+#### Update a file [PUT]
 
 + Request (application/json)
     + Attributes (object)
-        + `id` (string, required) - UUID of space
-        + `file_id` (string, required) - ID of file
-        + `format` (string, optional) - format of the resonse `json, html`
+        + `file_info` (object)
+            + `name` (string, optional) - file name
+            + `description` (string, optional) - brief description of the file
+            + `tag_list` (string, optional) - list of tags separated by commas
 
 + Response 200 (application/json)
-    + Attributes (object)
-        + `file` (object) - file attributes
 
-### Update a file [PUT /spaces/:id/file/files/:file_id]
+    - This returns a hash of file attributes, tags of files and recent 
+      activities of files.
 
-+ Request (application/json)
     + Attributes (object)
-        + `id` (string, required) - UUID of space
-        + `file_id` (string, required) - ID of file
-        + `file_info[name]` (string, optional) - ID of file
-        + `file_info[desciption]` (string, optional) - list of tags separated by commas
-
-+ Response 200 (application/json)
-    + Attributes (object)
-        + `file` (object) - file attributes
-        + `tags` (object) - hash of tags
-            + `all_tags` (array) - the array of all tags in space
-            + `related_tags` (array) - array of tags related to current file
-            + `selected_tags` (array) - array of the selected tags
-        + `recent_activity` (array) - array of recent activities of files
-            + `id` (number)
+        + `file` (File)
+        + `tags` (object)
+            + `all_tags` (array[string]) - the array of all tags in space
+            + `related_tags` (array[string]) - array of tags related to current file
+            + `selected_tags` (array[string]) - array of the selected tags
+        + `recent_activity` (array[object]) - array of recent activities of files
+            + `date` (DatetimeString) - the date of the activities in format "%A, %B %d, %Y"
+            + `links` (array) - the array of recent updated files inside the grouped date
+                + (object)
+                    + `id` (number) - the ID of the file
+                    + `name` (string) - the name of the file
+                    + `path` (string) - the relative path of the link to the file
 
 + Response 422 (application/json)
-    + Attributes (object)
-        + `hash` (object) - hash of errors
+    - hash of errors
 
-### Delete a file [DELETE /spaces/:id/file/files/:file_id]
+    + Attributes (object)
+
+#### Delete a file [DELETE /spaces/{space_id}/file/files/{file_ids}]
+
++ Parameters
+    + `file_ids` (id) - ID of a file or multiple IDs separated by commas
 
 + Request (application/json)
-    + Attributes (object)
-        + `id` (string, required) - UUID of space
-        + `file_id` (string, required) - ID of file or array of IDs
 
 + Response 200 (application/json)
+
+    - This returns a hash of statistics of deleting the files.
+
     + Attributes (object)
         + `message` (object)
             + `records_name` (string) - name of record
@@ -2294,79 +2378,62 @@ This is the Ribose API.
             + `ok_count` (number) - number of successful files, only returned when deleting more than one file
             + `total_count` (number) - number of total files, only returned when files failed to delete
 
-### Get a file icon [GET /spaces/:id/file/files/]
+#### Get a file icon [GET /spaces/{space_id}/file/files/{file_id}/icon]
 
 + Request (application/json)
-    + Attributes (object)
-        + `id` (string, required) - UUID of space
-        + `file_id` (string, required) - ID of file
 
 + Response 200 (application/json)
     + Attributes (object)
         + `icon_processed` (boolean) - the file icon has been processed or not
         + `icon_path` (string) - path of the file icon
 
-### Download a file [GET /spaces/:id/file/files/:file_id/download]
+#### Download a file [GET /spaces/{space_id}/file/files/{file_ids}/download]
+
++ Parameters
+    + `file_ids` (id) - ID of a file or multiple IDs separated by commas
+
++ Response 200
+
+    - Redirects to download link of the selected files
+    + Body
+
+#### Show a file version [GET /spaces/{space_id}/file/files/{file_id}/versions/{file_version_id}]
+
++ Parameters
+    + `file_version_id` (id) - ID of file
+
++ Response 200
+
+    - Redirects to download link of the version of the file
+    + Body
+
+#### Upload a file version [POST /spaces/{space_id}/file/files/{file_id}/versions/upload]
 
 + Request (application/json)
     + Attributes (object)
-        + `id` (string, required) - UUID of space
-        + `file_id` (string, required) - ID of file or array of IDs
-
-+ Response 200 (application/json)
-    + Attributes
-
-### Show a file version [GET /spaces/:id/file/files/:file_id/versions/:file_version:id]
-
-+ Request (application/json)
-    + Attributes (object)
-        + `id` (string, required) - UUID of space
-        + `file_id` (string, required) - ID of file
-        + `file_version_id` (string, required) - ID of file version
-
-+ Response 200 (application/json)
-    + Attributes
-
-### Upload a file version [POST /spaces/:id/file/files/:file_id/versions/upload]
-
-+ Request (application/json)
-    + Attributes (object)
-        + `id` (string, required) - UUID of space
-        + `file_id` (string, required) - ID of file
-        + `file_version_id` (string, required) - ID of file version
-        + `file_info_version` (string, optional) - description of the file version
+        + `file_info_version` (object)
+            + `attachment` (required) - the file to be uploaded as a new version
+            + `description` (string, optional) - description of the new file version
 
 + Response 200 (application/json)
     + Attributes (object)
-        + `attachment` (object) - file version attributes
-            + `author` (string) - name of the author
-            + `content_size` (number) - content size of the file version
-            + `content_type` (string) - content type of the file version
-            + `created_at` (string) - date of when the file version was created
-            + `current_version_id` (string) - current version ID of the version of the file
-            + `description` (string) - description of the file version
-            + `file_info_id` (string) - version ID of the version of the file
-            + `icon_path` (string) - path of the thumbnail of the file version
-            + `name` (string) - name of the file version
-            + `position` (number) - number of the order in position of the file version
-            + `updated_at` (string) - when the file version was updated
-            + `version` (number) - version number of the file
+        + `attachment` (FileVersion)
 
 + Response 422 (application/json)
     + Attributes (object)
         + `attachment_errors` (string) - error message
 
-### Revert a file version [GET /spaces/:id/file/files/:file_id/versions/:file_version_id/revert]
+#### Revert a file version [PUT /spaces/{space_id}/file/files/{file_id}/versions/{file_version_id}/revert]
+
+    -  `GET` would also work
+
++ Parameters
+    + `file_version_id` (id) - ID of file
 
 + Request (application/json)
-    + Attributes (object)
-        + `id` (string, required) - UUID of space
-        + `file_id` (string, required) - ID of file
-        + `file_version_id` (string, required) - ID of file version
 
 + Response 200 (application/json)
-    + Attributes (object)
-        + `hash` (object) - file attributes
+    + Attributes (File)
 ## Group Invitation
 
 ### Invitation to Ribose [/invitations/to_new_member/{invitation_id}]
@@ -2944,10 +3011,8 @@ This is the Ribose API.
         + `email` (string, required) - email address of user
 
 + Response 200 (application/json)
-    + Attributes
 
 + Response 422 (application/json)
-    + Attributes
 
 ### Submit sign-up details [POST /signup.user]
 
@@ -2963,5 +3028,4 @@ This is the Ribose API.
         + `name` (string) - username
 
 + Response 422 (application/json)
-    + Attributes
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -7,10 +7,9 @@ HOST: https://www.ribose.com/
 
 This is the Ribose API.
 
-[comment]: <> (REFERENCE section)
+[comment]: <> (DATA STRUCTURES section, has to be on top)
 
 ## Data Structures
-
 
 
 ### DatetimeString (string)
@@ -128,6 +127,110 @@ This is the Ribose API.
 * `id` (uuid)
 * `name` (string) - Space name
 * `members_count` (number) - how many members it contains
+
+[comment]: <> (REFERENCE section)
+
+## Group General
+
+### Log in [POST /login]
+
++ Request (application/json)
+    + Attributes (object)
+        + `utf8` (string, required) - UTF8 string
+        + `authenticity_token` (string, required) - CSRF prevention
+        + `invitation_code` (string, required) - invitation code
+        + `return_to` (string, required) - URL redirection parameter
+        + `username` (string, required) - username or email
+        + `password` (string, required) - password
+        + `remember_me` (boolean, required) - remember login
+
++ Response 200 (application/json)
+    + Attributes (object)
+
+### Log out [DELETE /logout]
+
++ Request (application/json)
+    + Attributes (object)
+
++ Response 204 (application/json)
+    + Attributes (object)
+
+### Request information [GET /app_data]
+
++ Request (application/json)
+    + Attributes (object)
+
++ Response 200 (application/json)
+    + Attributes (object)
+        + `self_profile` (object) - profile of current user
+            + `user_id` (string) - ID of current user
+            + `name` (string) - name of current user
+            + `login_name` (string) - login name of current user
+            + `activity_profile` (string) - activity profile of current user
+        + `status_message` (string) - status message for current user
+        + `number_of_connections` (number) - how many current connections are active
+        + `notification` (object)
+            + `item_id` (string) - last received notification item ID
+            + `read_item_it` (string) - last read notification item ID
+
+### Request settings [GET /settings]
+
++ Request (application/json)
+    + Attributes (object)
+
++ Response 200 (application/json)
+    + Attributes (object)
+
+### Request spaces [GET /spaces]
+
++ Request (application/json)
+    + Attributes (object)
+
++ Response 200 (application/json)
+    + Attributes (object)
+        + `id` (number) - space ID
+        + `name` (string) - name of the space
+        + `joined_at` (string) - date of when the user joined the space
+        + `created_at` (string) - date of when the space was created
+        + `owned_roles` (array) - array of objects representing a space role related to the space
+        + `access` (string) - options
+        + `active` (boolean) - whether the space is active or not
+        + `owner` (boolean) - whether the user is the owner of the space
+        + `role_name` (string) - role of the current user, can be `Administrator`, `Member`, or `Read only`
+        + `description` (string) - description of the space
+        + `members_count` (number) - number of members in the space
+        + `visibility` (string) - visibility of the space, can be `visible`, `visible_name`, or `invisible`
+
+### Request space members [GET /spaces/:id/members]
+
++ Request (application/json)
+    + Attributes (object)
+        + `id` (string, required) - UUID of space
+
++ Response 200 (application/json)
+    + Attributes (object)
+        + `id` (string) - user ID
+        + `connected` (boolean) - if the user is connected or not
+        + `mutual_spaces` (array) - array of spaces that are shared by user and space member
+        + `owner` (boolean) - whether user is owner of space or not
+        + `admin` (boolean) - whether user has administrator access to space
+        + `role_name_in_space` (string) - role of the current user, can be `Administrator`, `Member`, or `Read only`
+        + `indices` (object)
+        + `total` (number) - total number of items in the collection
+
+### User connections [GET /people/connections]
+
++ Request (application/json)
+    + Attributes (object)
+
++ Response 200 (application/json)
+    + Attributes (object)
+        + `id` (string) - user ID
+        + `login` (string) - user login name
+        + `jid` (string) - Jabber/XMPP ID of the user
+        + `mutual_spaces` (array) - array of spaces that are shared by user and space member
+        + `name` (string) - name of the user
+        + `status_message` (string) - status message of the user
 ## Group Self Profile
 
 ### Self Profile [/people/profile]
@@ -2089,173 +2192,181 @@ This is the Ribose API.
         }
 
 
-## File
+## Group File
 
-### File API
+### Upload a file [POST /spaces/:id/file/files/upload]
 
-#### Upload a file [POST /spaces/:id/file/files/upload]
-
-  + Attributes
-    + `id` (required, string) - UUID of space
-    + `file_info[attachment][]` (required, array) - array of files to be uploaded
-    + `file_info[tag_list]` (required, string) - list of tags separated by commas
-    + `file_info[description]` (optional, string) - description of the file
-
-  + Response 200 (application/json)
++ Request (application/json)
     + Attributes (object)
-      + `attachment` (object) - the file attributes
+        + `id` (required, string) - UUID of space
+        + `file_info[attachment][]` (required, array) - array of files to be uploaded
+        + `file_info[tag_list]` (required, string) - list of tags separated by commas
+        + `file_info[description]` (optional, string) - description of the file
 
-  + Response 422 (application/json)
++ Response 200 (application/json)
     + Attributes (object)
-      + `attachment_errors` (string) - the error message
+        + `attachment` (object) - the file attributes
 
-#### List files [GET /spaces/:id/file/files]
-
-  + Attributes
-    + `id` (required, string) - UUID of space
-    + `order_by` (optional, string) - sort order of files, `name, size, date, author, file_type`, default `date`
-    + `direction` (optional, string) - sort direction of files, `asc, desc`, default desc
-    + `start` (optional, number) - starting index of file collection, default 0
-    + `length` (optional, number) - maximum size of collection, default 100
-
-  + Response 200 (application/json)
++ Response 422 (application/json)
     + Attributes (object)
-      + `total` (number) - total number of files
-      + `indices` (object) - hash of index-file_id
-      + `objects` (array) - array of file attributes
-      + `tags` (object) - hash of tags
-        + `all_tags` (array) - the array of all tags in space
-        + `related_tags` (array) - array of tags related to the current file
-        + `selected_tags` (array) - array of selected tags
-      + `recent_activity` (array) - array of recent activities of files
-        + `date` (string) - the date of the activities in format `%A, %B %d, %Y`
-        + `links` (array) - the array of recent updated files inside the grouped date
-          + `id` (number) - the ID of the file
-          + `name` (string) - the name of the file
-          + `path` (string) - the relative path of the link to the file
-      + `permissions` (object) - the hash of the permissions of the user
-        + `allow_create` (boolean) - the permission of the user to create a file
-        + `allow_delete` (boolean) - the permission of the user to delete a file
-        + `allow_download` (boolean) - the permission of the user to download a file
-        + `allow_edit` (boolean) - the permission of the user to edit a file
-        + `allow_mass_actions` (boolean) - the permission of the user to perform mass actions on files
+        + `attachment_errors` (string) - the error message
 
+### List files [GET /spaces/:id/file/files]
 
-#### Show a file [GET /spaces/:id/file/files/:file_id]
-
-  + Attributes
-    + `id` (string, required) - UUID of space
-    + `file_id` (string, required) - ID of file
-    + `format` (string, optional) - format of the resonse `json, html`
-
-  + Response 200 (application/json)
++ Request (application/json)
     + Attributes (object)
-      + `file` (object) - file attributes
+        + `id` (required, string) - UUID of space
+        + `order_by` (optional, string) - sort order of files, `name, size, date, author, file_type`, default `date`
+        + `direction` (optional, string) - sort direction of files, `asc, desc`, default desc
+        + `start` (optional, number) - starting index of file collection, default 0
+        + `length` (optional, number) - maximum size of collection, default 100
 
-#### Update a file [PUT /spaces/:id/file/files/:file_id]
-
-  + Attributes
-    + `id` (string, required) - UUID of space
-    + `file_id` (string, required) - ID of file
-    + `file_info[name]` (string, optional) - ID of file
-    + `file_info[desciption]` (string, optional) - list of tags separated by commas
-
-  + Response 200 (application/json)
++ Response 200 (application/json)
     + Attributes (object)
-      + `file` (object) - file attributes
-      + `tags` (object) - hash of tags
-        + `all_tags` (array) - the array of all tags in space
-        + `related_tags` (array) - array of tags related to current file
-        + `selected_tags` (array) - array of the selected tags
-      + `recent_activity` (array) - array of recent activities of files
-        + `id` (number)
+        + `total` (number) - total number of files
+        + `indices` (object) - hash of index-file_id
+        + `objects` (array) - array of file attributes
+        + `tags` (object) - hash of tags
+            + `all_tags` (array) - the array of all tags in space
+            + `related_tags` (array) - array of tags related to the current file
+            + `selected_tags` (array) - array of selected tags
+        + `recent_activity` (array) - array of recent activities of files
+            + `date` (string) - the date of the activities in format `%A, %B %d, %Y`
+            + `links` (array) - the array of recent updated files inside the grouped date
+                + `id` (number) - the ID of the file
+                + `name` (string) - the name of the file
+                + `path` (string) - the relative path of the link to the file
+        + `permissions` (object) - the hash of the permissions of the user
+            + `allow_create` (boolean) - the permission of the user to create a file
+            + `allow_delete` (boolean) - the permission of the user to delete a file
+            + `allow_download` (boolean) - the permission of the user to download a file
+            + `allow_edit` (boolean) - the permission of the user to edit a file
+            + `allow_mass_actions` (boolean) - the permission of the user to perform mass actions on files
 
-  + Response 422 (application/json)
+
+### Show a file [GET /spaces/:id/file/files/:file_id]
+
++ Request (application/json)
     + Attributes (object)
-      + `hash` (object) - hash of errors
+        + `id` (string, required) - UUID of space
+        + `file_id` (string, required) - ID of file
+        + `format` (string, optional) - format of the resonse `json, html`
 
-#### Delete a file [DELETE /spaces/:id/file/files/:file_id]
-
-  + Attributes
-    + `id` (string, required) - UUID of space
-    + `file_id` (string, required) - ID of file or array of IDs
-
-  + Response 200 (application/json)
++ Response 200 (application/json)
     + Attributes (object)
-      + `message` (object)
-        + `records_name` (string) - name of record
-        + `action_name` (string) - name of action
-        + `ok_count` (number) - number of successful files, only returned when deleting more than one file
-        + `total_count` (number) - number of total files, only returned when files failed to delete
+        + `file` (object) - file attributes
 
-#### Get a file icon [GET /spaces/:id/file/files/]
+### Update a file [PUT /spaces/:id/file/files/:file_id]
 
-  + Attributes
-    + `id` (string, required) - UUID of space
-    + `file_id` (string, required) - ID of file
-
-  + Response 200 (application/json)
++ Request (application/json)
     + Attributes (object)
-      + `icon_processed` (boolean) - the file icon has been processed or not
-      + `icon_path` (string) - path of the file icon
+        + `id` (string, required) - UUID of space
+        + `file_id` (string, required) - ID of file
+        + `file_info[name]` (string, optional) - ID of file
+        + `file_info[desciption]` (string, optional) - list of tags separated by commas
 
-#### Download a file [GET /spaces/:id/file/files/:file_id/download]
++ Response 200 (application/json)
+    + Attributes (object)
+        + `file` (object) - file attributes
+        + `tags` (object) - hash of tags
+            + `all_tags` (array) - the array of all tags in space
+            + `related_tags` (array) - array of tags related to current file
+            + `selected_tags` (array) - array of the selected tags
+        + `recent_activity` (array) - array of recent activities of files
+            + `id` (number)
 
-  + Attributes
-    + `id` (string, required) - UUID of space
-    + `file_id` (string, required) - ID of file or array of IDs
++ Response 422 (application/json)
+    + Attributes (object)
+        + `hash` (object) - hash of errors
 
-  + Response 200 (application/json)
+### Delete a file [DELETE /spaces/:id/file/files/:file_id]
+
++ Request (application/json)
+    + Attributes (object)
+        + `id` (string, required) - UUID of space
+        + `file_id` (string, required) - ID of file or array of IDs
+
++ Response 200 (application/json)
+    + Attributes (object)
+        + `message` (object)
+            + `records_name` (string) - name of record
+            + `action_name` (string) - name of action
+            + `ok_count` (number) - number of successful files, only returned when deleting more than one file
+            + `total_count` (number) - number of total files, only returned when files failed to delete
+
+### Get a file icon [GET /spaces/:id/file/files/]
+
++ Request (application/json)
+    + Attributes (object)
+        + `id` (string, required) - UUID of space
+        + `file_id` (string, required) - ID of file
+
++ Response 200 (application/json)
+    + Attributes (object)
+        + `icon_processed` (boolean) - the file icon has been processed or not
+        + `icon_path` (string) - path of the file icon
+
+### Download a file [GET /spaces/:id/file/files/:file_id/download]
+
++ Request (application/json)
+    + Attributes (object)
+        + `id` (string, required) - UUID of space
+        + `file_id` (string, required) - ID of file or array of IDs
+
++ Response 200 (application/json)
     + Attributes
 
-#### Show a file version [GET /spaces/:id/file/files/:file_id/versions/:file_version:id]
+### Show a file version [GET /spaces/:id/file/files/:file_id/versions/:file_version:id]
 
-  + Attributes
-    + `id` (string, required) - UUID of space
-    + `file_id` (string, required) - ID of file
-    + `file_version_id` (string, required) - ID of file version
++ Request (application/json)
+    + Attributes (object)
+        + `id` (string, required) - UUID of space
+        + `file_id` (string, required) - ID of file
+        + `file_version_id` (string, required) - ID of file version
 
-  + Response 200 (application/json)
++ Response 200 (application/json)
     + Attributes
 
-#### Upload a file version [POST /spaces/:id/file/files/:file_id/versions/upload]
+### Upload a file version [POST /spaces/:id/file/files/:file_id/versions/upload]
 
-  + Attributes
-    + `id` (string, required) - UUID of space
-    + `file_id` (string, required) - ID of file
-    + `file_version_id` (string, required) - ID of file version
-    + `file_info_version` (string, optional) - description of the file version
-
-  + Response 200 (application/json)
++ Request (application/json)
     + Attributes (object)
-      + `attachment` (object) - file version attributes
-        + `author` (string) - name of the author
-        + `content_size` (number) - content size of the file version
-        + `content_type` (string) - content type of the file version
-        + `created_at` (string) - date of when the file version was created
-        + `current_version_id` (string) - current version ID of the version of the file
-        + `description` (string) - description of the file version
-        + `file_info_id` (string) - version ID of the version of the file
-        + `icon_path` (string) - path of the thumbnail of the file version
-        + `name` (string) - name of the file version
-        + `position` (number) - number of the order in position of the file version
-        + `updated_at` (string) - when the file version was updated
-        + `version` (number) - version number of the file
+        + `id` (string, required) - UUID of space
+        + `file_id` (string, required) - ID of file
+        + `file_version_id` (string, required) - ID of file version
+        + `file_info_version` (string, optional) - description of the file version
 
-  + Response 422 (application/json)
++ Response 200 (application/json)
     + Attributes (object)
-      + `attachment_errors` (string) - error message
+        + `attachment` (object) - file version attributes
+            + `author` (string) - name of the author
+            + `content_size` (number) - content size of the file version
+            + `content_type` (string) - content type of the file version
+            + `created_at` (string) - date of when the file version was created
+            + `current_version_id` (string) - current version ID of the version of the file
+            + `description` (string) - description of the file version
+            + `file_info_id` (string) - version ID of the version of the file
+            + `icon_path` (string) - path of the thumbnail of the file version
+            + `name` (string) - name of the file version
+            + `position` (number) - number of the order in position of the file version
+            + `updated_at` (string) - when the file version was updated
+            + `version` (number) - version number of the file
 
-#### Revert a file version [GET /spaces/:id/file/files/:file_id/versions/:file_version_id/revert]
-
-  + Attributes
-    + `id` (string, required) - UUID of space
-    + `file_id` (string, required) - ID of file
-    + `file_version_id` (string, required) - ID of file version
-
-  + Response 200 (application/json)
++ Response 422 (application/json)
     + Attributes (object)
-      + `hash` (object) - file attributes
+        + `attachment_errors` (string) - error message
+
+### Revert a file version [GET /spaces/:id/file/files/:file_id/versions/:file_version_id/revert]
+
++ Request (application/json)
+    + Attributes (object)
+        + `id` (string, required) - UUID of space
+        + `file_id` (string, required) - ID of file
+        + `file_version_id` (string, required) - ID of file version
+
++ Response 200 (application/json)
+    + Attributes (object)
+        + `hash` (object) - file attributes
 ## Group Invitation
 
 ### Invitation to Ribose [/invitations/to_new_member/{invitation_id}]
@@ -2814,42 +2925,43 @@ This is the Ribose API.
     + Attributes (object)
         + Body
                 {}
-## User
+## Group User Creation
 
-### User Creation API
+### Check email uniqueness [GET /signup_validation/check_user_field_uniqueness]
 
-#### Check email uniqueness [GET /signup_validation/check_user_field_uniqueness]
-
-  + Attributes
-    + `email` (string, required) - email address of user
-
-  + Response 200 (application/json)
++ request (application/json)
     + Attributes (object)
-      + `unique` (boolean)
+        + `email` (string, required) - email address of user
 
-#### Create sign-up request [POST /signup_requests]
++ Response 200 (application/json)
+    + Attributes (object)
+        + `unique` (boolean)
 
-  + Attributes
-    + `email` (string, required) - email address of user
+### Create sign-up request [POST /signup_requests]
 
-  + Response 200 (application/json)
++ request (application/json)
+    + Attributes (object)
+        + `email` (string, required) - email address of user
+
++ Response 200 (application/json)
     + Attributes
 
-  + Response 422 (application/json)
++ Response 422 (application/json)
     + Attributes
 
-#### Submit sign-up details [POST /signup.user]
+### Submit sign-up details [POST /signup.user]
 
-  + Attributes
-    + `email` (string, required) - email address of user
-    + `otp` (string, required) - OTP value from confirmation email
-    + `password` (string, required) - string of new password
++ request (application/json)
+    + Attributes (object)
+        + `email` (string, required) - email address of user
+        + `otp` (string, required) - OTP value from confirmation email
+        + `password` (string, required) - string of new password
 
-  + Response 201 (application/json)
-    + Attributes(object)
-      + `id` (string) - ID of new user
-      + `name` (string) - username
++ Response 201 (application/json)
+    + Attributes (object)
+        + `id` (string) - ID of new user
+        + `name` (string) - username
 
-  + Response 422 (application/json)
++ Response 422 (application/json)
     + Attributes
 

--- a/input.apib
+++ b/input.apib
@@ -7,12 +7,15 @@ HOST: https://www.ribose.com/
 
 This is the Ribose API.
 
-[comment]: <> (REFERENCE section)
+[comment]: <> (DATA STRUCTURES section, has to be on top)
 
 ## Data Structures
 
-:[](sections/general.apib)
 :[](sections/common_ds.apib)
+
+[comment]: <> (REFERENCE section)
+
+:[](sections/general.apib)
 :[](sections/profile.apib)
 :[](sections/app_data.apib)
 :[](sections/calendar.apib)

--- a/sections/common_ds.apib
+++ b/sections/common_ds.apib
@@ -114,3 +114,51 @@
 * `id` (uuid)
 * `name` (string) - Space name
 * `members_count` (number) - how many members it contains
+
+### File (object)
+
++ `allow_create` (boolean) - the permission of User to create a file
++ `allow_delete` (boolean) - the permission of User to delete a file
++ `allow_download` (boolean) - the permission of User to download a file
++ `allow_edit` (boolean) - the permission of User to edit a file
++ `allow_update` (boolean) - the permission of User to update a file
++ `author` (string) - the name of User
++ `content_size` (number) - the content size of the file
++ `content_type` (string) - the content type of the file
++ `created_at` (DatetimeString) - of when the file created
++ `current_version_id` (id) - the current version id of the version of the file
++ `description` (string) - the description of the file
++ `id` (id) - the id of the file
++ `name` (string) - the name of the file
++ `tag_list` (array[string]) - the list of tags
++ `updated_at` (DatetimeString) - of when the file updated
++ `version` (number) - the version number of the array of the file versions
++ `versions` (array[object]) - the array of the file version objects with attributes:
+    + (object)
+        + `author` (string) - the name of the author
+        + `content_size` (number) - the content size of the file version
+        + `content_type` (string) - the content type of the file version
+        + `created_at` (DatetimeString) of when the file version created
+        + `current_version_id` (id) - the current version id of the version of the file
+        + `description` (string) - the description of the file version
+        + `file_info_id` (id) - the version id of the version of the file
+        + `icon_path` (string) - the path of the thumbnail of the file version
+        + `name` (string) - the name of the file version
+        + `position` (number) - the number of the order in position of the file version
+        + `updated_at` (DatetimeString) - of when the file version updated
+        + `version` (number) - the version number of the file version
+
+### FileVersion (object)
+
++ `author` (string) - name of the author
++ `content_size` (number) - content size of the file version
++ `content_type` (string) - content type of the file version
++ `created_at` (DatetimeString) - date of when the file version was created
++ `current_version_id` (id) - current version ID of the version of the file
++ `description` (string) - description of the file version
++ `file_info_id` (id) - version ID of the version of the file
++ `icon_path` (string) - path of the thumbnail of the file version
++ `name` (string) - name of the file version
++ `position` (number) - number of the order in position of the file version
++ `updated_at` (DatetimeString) - when the file version was updated
++ `version` (number) - version number of the file

--- a/sections/file.apib
+++ b/sections/file.apib
@@ -1,167 +1,173 @@
-## File
+## Group File
 
-### File API
+### Upload a file [POST /spaces/:id/file/files/upload]
 
-#### Upload a file [POST /spaces/:id/file/files/upload]
-
-  + Attributes
-    + `id` (required, string) - UUID of space
-    + `file_info[attachment][]` (required, array) - array of files to be uploaded
-    + `file_info[tag_list]` (required, string) - list of tags separated by commas
-    + `file_info[description]` (optional, string) - description of the file
-
-  + Response 200 (application/json)
++ Request (application/json)
     + Attributes (object)
-      + `attachment` (object) - the file attributes
+        + `id` (required, string) - UUID of space
+        + `file_info[attachment][]` (required, array) - array of files to be uploaded
+        + `file_info[tag_list]` (required, string) - list of tags separated by commas
+        + `file_info[description]` (optional, string) - description of the file
 
-  + Response 422 (application/json)
++ Response 200 (application/json)
     + Attributes (object)
-      + `attachment_errors` (string) - the error message
+        + `attachment` (object) - the file attributes
 
-#### List files [GET /spaces/:id/file/files]
-
-  + Attributes
-    + `id` (required, string) - UUID of space
-    + `order_by` (optional, string) - sort order of files, `name, size, date, author, file_type`, default `date`
-    + `direction` (optional, string) - sort direction of files, `asc, desc`, default desc
-    + `start` (optional, number) - starting index of file collection, default 0
-    + `length` (optional, number) - maximum size of collection, default 100
-
-  + Response 200 (application/json)
++ Response 422 (application/json)
     + Attributes (object)
-      + `total` (number) - total number of files
-      + `indices` (object) - hash of index-file_id
-      + `objects` (array) - array of file attributes
-      + `tags` (object) - hash of tags
-        + `all_tags` (array) - the array of all tags in space
-        + `related_tags` (array) - array of tags related to the current file
-        + `selected_tags` (array) - array of selected tags
-      + `recent_activity` (array) - array of recent activities of files
-        + `date` (string) - the date of the activities in format `%A, %B %d, %Y`
-        + `links` (array) - the array of recent updated files inside the grouped date
-          + `id` (number) - the ID of the file
-          + `name` (string) - the name of the file
-          + `path` (string) - the relative path of the link to the file
-      + `permissions` (object) - the hash of the permissions of the user
-        + `allow_create` (boolean) - the permission of the user to create a file
-        + `allow_delete` (boolean) - the permission of the user to delete a file
-        + `allow_download` (boolean) - the permission of the user to download a file
-        + `allow_edit` (boolean) - the permission of the user to edit a file
-        + `allow_mass_actions` (boolean) - the permission of the user to perform mass actions on files
+        + `attachment_errors` (string) - the error message
 
+### List files [GET /spaces/:id/file/files]
 
-#### Show a file [GET /spaces/:id/file/files/:file_id]
-
-  + Attributes
-    + `id` (string, required) - UUID of space
-    + `file_id` (string, required) - ID of file
-    + `format` (string, optional) - format of the resonse `json, html`
-
-  + Response 200 (application/json)
++ Request (application/json)
     + Attributes (object)
-      + `file` (object) - file attributes
+        + `id` (required, string) - UUID of space
+        + `order_by` (optional, string) - sort order of files, `name, size, date, author, file_type`, default `date`
+        + `direction` (optional, string) - sort direction of files, `asc, desc`, default desc
+        + `start` (optional, number) - starting index of file collection, default 0
+        + `length` (optional, number) - maximum size of collection, default 100
 
-#### Update a file [PUT /spaces/:id/file/files/:file_id]
-
-  + Attributes
-    + `id` (string, required) - UUID of space
-    + `file_id` (string, required) - ID of file
-    + `file_info[name]` (string, optional) - ID of file
-    + `file_info[desciption]` (string, optional) - list of tags separated by commas
-
-  + Response 200 (application/json)
++ Response 200 (application/json)
     + Attributes (object)
-      + `file` (object) - file attributes
-      + `tags` (object) - hash of tags
-        + `all_tags` (array) - the array of all tags in space
-        + `related_tags` (array) - array of tags related to current file
-        + `selected_tags` (array) - array of the selected tags
-      + `recent_activity` (array) - array of recent activities of files
-        + `id` (number)
+        + `total` (number) - total number of files
+        + `indices` (object) - hash of index-file_id
+        + `objects` (array) - array of file attributes
+        + `tags` (object) - hash of tags
+            + `all_tags` (array) - the array of all tags in space
+            + `related_tags` (array) - array of tags related to the current file
+            + `selected_tags` (array) - array of selected tags
+        + `recent_activity` (array) - array of recent activities of files
+            + `date` (string) - the date of the activities in format `%A, %B %d, %Y`
+            + `links` (array) - the array of recent updated files inside the grouped date
+                + `id` (number) - the ID of the file
+                + `name` (string) - the name of the file
+                + `path` (string) - the relative path of the link to the file
+        + `permissions` (object) - the hash of the permissions of the user
+            + `allow_create` (boolean) - the permission of the user to create a file
+            + `allow_delete` (boolean) - the permission of the user to delete a file
+            + `allow_download` (boolean) - the permission of the user to download a file
+            + `allow_edit` (boolean) - the permission of the user to edit a file
+            + `allow_mass_actions` (boolean) - the permission of the user to perform mass actions on files
 
-  + Response 422 (application/json)
+
+### Show a file [GET /spaces/:id/file/files/:file_id]
+
++ Request (application/json)
     + Attributes (object)
-      + `hash` (object) - hash of errors
+        + `id` (string, required) - UUID of space
+        + `file_id` (string, required) - ID of file
+        + `format` (string, optional) - format of the resonse `json, html`
 
-#### Delete a file [DELETE /spaces/:id/file/files/:file_id]
-
-  + Attributes
-    + `id` (string, required) - UUID of space
-    + `file_id` (string, required) - ID of file or array of IDs
-
-  + Response 200 (application/json)
++ Response 200 (application/json)
     + Attributes (object)
-      + `message` (object)
-        + `records_name` (string) - name of record
-        + `action_name` (string) - name of action
-        + `ok_count` (number) - number of successful files, only returned when deleting more than one file
-        + `total_count` (number) - number of total files, only returned when files failed to delete
+        + `file` (object) - file attributes
 
-#### Get a file icon [GET /spaces/:id/file/files/]
+### Update a file [PUT /spaces/:id/file/files/:file_id]
 
-  + Attributes
-    + `id` (string, required) - UUID of space
-    + `file_id` (string, required) - ID of file
-
-  + Response 200 (application/json)
++ Request (application/json)
     + Attributes (object)
-      + `icon_processed` (boolean) - the file icon has been processed or not
-      + `icon_path` (string) - path of the file icon
+        + `id` (string, required) - UUID of space
+        + `file_id` (string, required) - ID of file
+        + `file_info[name]` (string, optional) - ID of file
+        + `file_info[desciption]` (string, optional) - list of tags separated by commas
 
-#### Download a file [GET /spaces/:id/file/files/:file_id/download]
-
-  + Attributes
-    + `id` (string, required) - UUID of space
-    + `file_id` (string, required) - ID of file or array of IDs
-
-  + Response 200 (application/json)
-    + Attributes
-
-#### Show a file version [GET /spaces/:id/file/files/:file_id/versions/:file_version:id]
-
-  + Attributes
-    + `id` (string, required) - UUID of space
-    + `file_id` (string, required) - ID of file
-    + `file_version_id` (string, required) - ID of file version
-
-  + Response 200 (application/json)
-    + Attributes
-
-#### Upload a file version [POST /spaces/:id/file/files/:file_id/versions/upload]
-
-  + Attributes
-    + `id` (string, required) - UUID of space
-    + `file_id` (string, required) - ID of file
-    + `file_version_id` (string, required) - ID of file version
-    + `file_info_version` (string, optional) - description of the file version
-
-  + Response 200 (application/json)
++ Response 200 (application/json)
     + Attributes (object)
-      + `attachment` (object) - file version attributes
-        + `author` (string) - name of the author
-        + `content_size` (number) - content size of the file version
-        + `content_type` (string) - content type of the file version
-        + `created_at` (string) - date of when the file version was created
-        + `current_version_id` (string) - current version ID of the version of the file
-        + `description` (string) - description of the file version
-        + `file_info_id` (string) - version ID of the version of the file
-        + `icon_path` (string) - path of the thumbnail of the file version
-        + `name` (string) - name of the file version
-        + `position` (number) - number of the order in position of the file version
-        + `updated_at` (string) - when the file version was updated
-        + `version` (number) - version number of the file
+        + `file` (object) - file attributes
+        + `tags` (object) - hash of tags
+            + `all_tags` (array) - the array of all tags in space
+            + `related_tags` (array) - array of tags related to current file
+            + `selected_tags` (array) - array of the selected tags
+        + `recent_activity` (array) - array of recent activities of files
+            + `id` (number)
 
-  + Response 422 (application/json)
++ Response 422 (application/json)
     + Attributes (object)
-      + `attachment_errors` (string) - error message
+        + `hash` (object) - hash of errors
 
-#### Revert a file version [GET /spaces/:id/file/files/:file_id/versions/:file_version_id/revert]
+### Delete a file [DELETE /spaces/:id/file/files/:file_id]
 
-  + Attributes
-    + `id` (string, required) - UUID of space
-    + `file_id` (string, required) - ID of file
-    + `file_version_id` (string, required) - ID of file version
-
-  + Response 200 (application/json)
++ Request (application/json)
     + Attributes (object)
-      + `hash` (object) - file attributes
+        + `id` (string, required) - UUID of space
+        + `file_id` (string, required) - ID of file or array of IDs
+
++ Response 200 (application/json)
+    + Attributes (object)
+        + `message` (object)
+            + `records_name` (string) - name of record
+            + `action_name` (string) - name of action
+            + `ok_count` (number) - number of successful files, only returned when deleting more than one file
+            + `total_count` (number) - number of total files, only returned when files failed to delete
+
+### Get a file icon [GET /spaces/:id/file/files/]
+
++ Request (application/json)
+    + Attributes (object)
+        + `id` (string, required) - UUID of space
+        + `file_id` (string, required) - ID of file
+
++ Response 200 (application/json)
+    + Attributes (object)
+        + `icon_processed` (boolean) - the file icon has been processed or not
+        + `icon_path` (string) - path of the file icon
+
+### Download a file [GET /spaces/:id/file/files/:file_id/download]
+
++ Request (application/json)
+    + Attributes (object)
+        + `id` (string, required) - UUID of space
+        + `file_id` (string, required) - ID of file or array of IDs
+
++ Response 200 (application/json)
+
+### Show a file version [GET /spaces/:id/file/files/:file_id/versions/:file_version:id]
+
++ Request (application/json)
+    + Attributes (object)
+        + `id` (string, required) - UUID of space
+        + `file_id` (string, required) - ID of file
+        + `file_version_id` (string, required) - ID of file version
+
++ Response 200 (application/json)
+
+### Upload a file version [POST /spaces/:id/file/files/:file_id/versions/upload]
+
++ Request (application/json)
+    + Attributes (object)
+        + `id` (string, required) - UUID of space
+        + `file_id` (string, required) - ID of file
+        + `file_version_id` (string, required) - ID of file version
+        + `file_info_version` (string, optional) - description of the file version
+
++ Response 200 (application/json)
+    + Attributes (object)
+        + `attachment` (object) - file version attributes
+            + `author` (string) - name of the author
+            + `content_size` (number) - content size of the file version
+            + `content_type` (string) - content type of the file version
+            + `created_at` (string) - date of when the file version was created
+            + `current_version_id` (string) - current version ID of the version of the file
+            + `description` (string) - description of the file version
+            + `file_info_id` (string) - version ID of the version of the file
+            + `icon_path` (string) - path of the thumbnail of the file version
+            + `name` (string) - name of the file version
+            + `position` (number) - number of the order in position of the file version
+            + `updated_at` (string) - when the file version was updated
+            + `version` (number) - version number of the file
+
++ Response 422 (application/json)
+    + Attributes (object)
+        + `attachment_errors` (string) - error message
+
+### Revert a file version [GET /spaces/:id/file/files/:file_id/versions/:file_version_id/revert]
+
++ Request (application/json)
+    + Attributes (object)
+        + `id` (string, required) - UUID of space
+        + `file_id` (string, required) - ID of file
+        + `file_version_id` (string, required) - ID of file version
+
++ Response 200 (application/json)
+    + Attributes (object)
+        + `hash` (object) - file attributes

--- a/sections/file.apib
+++ b/sections/file.apib
@@ -1,37 +1,51 @@
 ## Group File
 
-### Upload a file [POST /spaces/:id/file/files/upload]
+### Upload a file [POST /spaces/{space_id}/file/files/upload]
+
++ Parameters
+    + `space_id` (uuid) - UUID of space
 
 + Request (application/json)
     + Attributes (object)
-        + `id` (required, string) - UUID of space
-        + `file_info[attachment][]` (required, array) - array of files to be uploaded
-        + `file_info[tag_list]` (required, string) - list of tags separated by commas
-        + `file_info[description]` (optional, string) - description of the file
+        + `file_info` (object)
+            + `attachment` (required, array) - array of files to be uploaded
+            + `description`: This is an important file (optional, string) - description of the file
+            + `tag_list`: tag1,tag2 (optional, string) - list of tags separated by commas
 
 + Response 200 (application/json)
     + Attributes (object)
-        + `attachment` (object) - the file attributes
+        + `attachment` (File)
 
 + Response 422 (application/json)
     + Attributes (object)
         + `attachment_errors` (string) - the error message
 
-### List files [GET /spaces/:id/file/files]
+### List files [GET /spaces/{space_id}/file/files]
+
++ Parameters
+    + `space_id` (uuid) - UUID of space
 
 + Request (application/json)
     + Attributes (object)
-        + `id` (required, string) - UUID of space
-        + `order_by` (optional, string) - sort order of files, `name, size, date, author, file_type`, default `date`
-        + `direction` (optional, string) - sort direction of files, `asc, desc`, default desc
-        + `start` (optional, number) - starting index of file collection, default 0
-        + `length` (optional, number) - maximum size of collection, default 100
+        + `order_by`: date (optional, enum[string]) - sort order of files
+            + Members
+                + name
+                + size
+                + date
+                + author
+                + file_type
+        + `direction`: desc (optional, enum[string]) - sort direction of files
+            + Members
+                + asc
+                + desc
+        + `start`: 0 (optional, number) - starting index of file collection, default: 0
+        + `length`: 100 (optional, number) - maximum size of collection, default: 100
 
 + Response 200 (application/json)
     + Attributes (object)
         + `total` (number) - total number of files
         + `indices` (object) - hash of index-file_id
-        + `objects` (array) - array of file attributes
+        + `objects` (array[File]) - array of file attributes
         + `tags` (object) - hash of tags
             + `all_tags` (array) - the array of all tags in space
             + `related_tags` (array) - array of tags related to the current file
@@ -39,9 +53,10 @@
         + `recent_activity` (array) - array of recent activities of files
             + `date` (string) - the date of the activities in format `%A, %B %d, %Y`
             + `links` (array) - the array of recent updated files inside the grouped date
-                + `id` (number) - the ID of the file
-                + `name` (string) - the name of the file
-                + `path` (string) - the relative path of the link to the file
+                + (object)
+                    + `id` (number) - the ID of the file
+                    + `name` (string) - the name of the file
+                    + `path` (string) - the relative path of the link to the file
         + `permissions` (object) - the hash of the permissions of the user
             + `allow_create` (boolean) - the permission of the user to create a file
             + `allow_delete` (boolean) - the permission of the user to delete a file
@@ -50,49 +65,74 @@
             + `allow_mass_actions` (boolean) - the permission of the user to perform mass actions on files
 
 
-### Show a file [GET /spaces/:id/file/files/:file_id]
+### File [/spaces/{space_id}/file/files/{file_id}]
+
++ Parameters
+    + `space_id` (uuid) - UUID of space
+    + `file_id` (id) - ID of file
+
+#### Show a file [GET]
+
++ Request (text/html)
+
++ Response 200
+
+    - Redirects to download link of the file
+    + Body
+
++ Request (application/json)
+
++ Response 200 (application/json)
+
+    - This returns a hash of file indices and an array of objects of files
+
+    + Attributes (object)
+        + `file` (File)
+
+#### Update a file [PUT]
 
 + Request (application/json)
     + Attributes (object)
-        + `id` (string, required) - UUID of space
-        + `file_id` (string, required) - ID of file
-        + `format` (string, optional) - format of the resonse `json, html`
+        + `file_info` (object)
+            + `name` (string, optional) - file name
+            + `description` (string, optional) - brief description of the file
+            + `tag_list` (string, optional) - list of tags separated by commas
 
 + Response 200 (application/json)
-    + Attributes (object)
-        + `file` (object) - file attributes
 
-### Update a file [PUT /spaces/:id/file/files/:file_id]
+    - This returns a hash of file attributes, tags of files and recent 
+      activities of files.
 
-+ Request (application/json)
     + Attributes (object)
-        + `id` (string, required) - UUID of space
-        + `file_id` (string, required) - ID of file
-        + `file_info[name]` (string, optional) - ID of file
-        + `file_info[desciption]` (string, optional) - list of tags separated by commas
-
-+ Response 200 (application/json)
-    + Attributes (object)
-        + `file` (object) - file attributes
-        + `tags` (object) - hash of tags
-            + `all_tags` (array) - the array of all tags in space
-            + `related_tags` (array) - array of tags related to current file
-            + `selected_tags` (array) - array of the selected tags
-        + `recent_activity` (array) - array of recent activities of files
-            + `id` (number)
+        + `file` (File)
+        + `tags` (object)
+            + `all_tags` (array[string]) - the array of all tags in space
+            + `related_tags` (array[string]) - array of tags related to current file
+            + `selected_tags` (array[string]) - array of the selected tags
+        + `recent_activity` (array[object]) - array of recent activities of files
+            + `date` (DatetimeString) - the date of the activities in format "%A, %B %d, %Y"
+            + `links` (array) - the array of recent updated files inside the grouped date
+                + (object)
+                    + `id` (number) - the ID of the file
+                    + `name` (string) - the name of the file
+                    + `path` (string) - the relative path of the link to the file
 
 + Response 422 (application/json)
-    + Attributes (object)
-        + `hash` (object) - hash of errors
+    - hash of errors
 
-### Delete a file [DELETE /spaces/:id/file/files/:file_id]
+    + Attributes (object)
+
+#### Delete a file [DELETE /spaces/{space_id}/file/files/{file_ids}]
+
++ Parameters
+    + `file_ids` (id) - ID of a file or multiple IDs separated by commas
 
 + Request (application/json)
-    + Attributes (object)
-        + `id` (string, required) - UUID of space
-        + `file_id` (string, required) - ID of file or array of IDs
 
 + Response 200 (application/json)
+
+    - This returns a hash of statistics of deleting the files.
+
     + Attributes (object)
         + `message` (object)
             + `records_name` (string) - name of record
@@ -100,74 +140,59 @@
             + `ok_count` (number) - number of successful files, only returned when deleting more than one file
             + `total_count` (number) - number of total files, only returned when files failed to delete
 
-### Get a file icon [GET /spaces/:id/file/files/]
+#### Get a file icon [GET /spaces/{space_id}/file/files/{file_id}/icon]
 
 + Request (application/json)
-    + Attributes (object)
-        + `id` (string, required) - UUID of space
-        + `file_id` (string, required) - ID of file
 
 + Response 200 (application/json)
     + Attributes (object)
         + `icon_processed` (boolean) - the file icon has been processed or not
         + `icon_path` (string) - path of the file icon
 
-### Download a file [GET /spaces/:id/file/files/:file_id/download]
+#### Download a file [GET /spaces/{space_id}/file/files/{file_ids}/download]
+
++ Parameters
+    + `file_ids` (id) - ID of a file or multiple IDs separated by commas
+
++ Response 200
+
+    - Redirects to download link of the selected files
+    + Body
+
+#### Show a file version [GET /spaces/{space_id}/file/files/{file_id}/versions/{file_version_id}]
+
++ Parameters
+    + `file_version_id` (id) - ID of file
+
++ Response 200
+
+    - Redirects to download link of the version of the file
+    + Body
+
+#### Upload a file version [POST /spaces/{space_id}/file/files/{file_id}/versions/upload]
 
 + Request (application/json)
     + Attributes (object)
-        + `id` (string, required) - UUID of space
-        + `file_id` (string, required) - ID of file or array of IDs
-
-+ Response 200 (application/json)
-
-### Show a file version [GET /spaces/:id/file/files/:file_id/versions/:file_version:id]
-
-+ Request (application/json)
-    + Attributes (object)
-        + `id` (string, required) - UUID of space
-        + `file_id` (string, required) - ID of file
-        + `file_version_id` (string, required) - ID of file version
-
-+ Response 200 (application/json)
-
-### Upload a file version [POST /spaces/:id/file/files/:file_id/versions/upload]
-
-+ Request (application/json)
-    + Attributes (object)
-        + `id` (string, required) - UUID of space
-        + `file_id` (string, required) - ID of file
-        + `file_version_id` (string, required) - ID of file version
-        + `file_info_version` (string, optional) - description of the file version
+        + `file_info_version` (object)
+            + `attachment` (required) - the file to be uploaded as a new version
+            + `description` (string, optional) - description of the new file version
 
 + Response 200 (application/json)
     + Attributes (object)
-        + `attachment` (object) - file version attributes
-            + `author` (string) - name of the author
-            + `content_size` (number) - content size of the file version
-            + `content_type` (string) - content type of the file version
-            + `created_at` (string) - date of when the file version was created
-            + `current_version_id` (string) - current version ID of the version of the file
-            + `description` (string) - description of the file version
-            + `file_info_id` (string) - version ID of the version of the file
-            + `icon_path` (string) - path of the thumbnail of the file version
-            + `name` (string) - name of the file version
-            + `position` (number) - number of the order in position of the file version
-            + `updated_at` (string) - when the file version was updated
-            + `version` (number) - version number of the file
+        + `attachment` (FileVersion)
 
 + Response 422 (application/json)
     + Attributes (object)
         + `attachment_errors` (string) - error message
 
-### Revert a file version [GET /spaces/:id/file/files/:file_id/versions/:file_version_id/revert]
+#### Revert a file version [PUT /spaces/{space_id}/file/files/{file_id}/versions/{file_version_id}/revert]
+
+    -  `GET` would also work
+
++ Parameters
+    + `file_version_id` (id) - ID of file
 
 + Request (application/json)
-    + Attributes (object)
-        + `id` (string, required) - UUID of space
-        + `file_id` (string, required) - ID of file
-        + `file_version_id` (string, required) - ID of file version
 
 + Response 200 (application/json)
-    + Attributes (object)
-        + `hash` (object) - file attributes
+    + Attributes (File)

--- a/sections/general.apib
+++ b/sections/general.apib
@@ -1,96 +1,97 @@
-## General
+## Group General
 
-### General API endpoints
+### Log in [POST /login]
 
-#### Log in [POST /login]
-
-  + Attributes
-    + `utf8` (string, required) - UTF8 string
-    + `authenticity_token` (string, required) - CSRF prevention
-    + `invitation_code` (string, required) - invitation code
-    + `return_to` (string, required) - URL redirection parameter
-    + `username` (string, required) - username or email
-    + `password` (string, required) - password
-    + `remember_me` (boolean, required) - remember login
-
-  + Response 200 (application/json)
-    + Attributes
-
-#### Log out [DELETE /logout]
-
-  + Attributes
-
-  + Response 204 (application/json)
-    + Attributes
-
-#### Request information [GET /app_data]
-
-  + Attributes
-
-  + Response 200 (application/json)
++ Request (application/json)
     + Attributes (object)
-      + `self_profile` (object) - profile of current user
-        + `user_id` (string) - ID of current user
-        + `name` (string) - name of current user
-        + `login_name` (string) - login name of current user
-        + `activity_profile` (string) - activity profile of current user
-      + `status_message` (string) - status message for current user
-      + `number_of_connections` (number) - how many current connections are active
-      + `notification` (object)
-        + `item_id` (string) - last received notification item ID
-        + `read_item_it` (string) - last read notification item ID
+        + `utf8` (string, required) - UTF8 string
+        + `authenticity_token` (string, required) - CSRF prevention
+        + `invitation_code` (string, required) - invitation code
+        + `return_to` (string, required) - URL redirection parameter
+        + `username` (string, required) - username or email
+        + `password` (string, required) - password
+        + `remember_me` (boolean, required) - remember login
 
-#### Request settings [GET /settings]
-
-  + Attributes
-
-  + Response 200 (application/json)
++ Response 200 (application/json)
     + Attributes (object)
 
-#### Request spaces [GET /spaces]
+### Log out [DELETE /logout]
 
-  + Attributes
-
-  + Response 200 (application/json)
++ Request (application/json)
     + Attributes (object)
-      + `id` (number) - space ID
-      + `name` (string) - name of the space
-      + `joined_at` (string) - date of when the user joined the space
-      + `created_at` (string) - date of when the space was created
-      + `owned_roles` (array) - array of objects representing a space role related to the space
-      + `access` (string) - options
-      + `active` (boolean) - whether the space is active or not
-      + `owner` (boolean) - whether the user is the owner of the space
-      + `role_name` (string) - role of the current user, can be `Administrator`, `Member`, or `Read only`
-      + `description` (string) - description of the space
-      + `members_count` (number) - number of members in the space
-      + `visibility` (string) - visibility of the space, can be `visible`, `visible_name`, or `invisible`
 
-#### Request space members [GET /spaces/:id/members]
-
-  + Attributes
-    + `id` (string, required) - UUID of space
-
-  + Response 200 (application/json)
++ Response 204 (application/json)
     + Attributes (object)
-      + `id` (string) - user ID
-      + `connected` (boolean) - if the user is connected or not
-      + `mutual_spaces` (array) - array of spaces that are shared by user and space member
-      + `owner` (boolean) - whether user is owner of space or not
-      + `admin` (boolean) - whether user has administrator access to space
-      + `role_name_in_space` (string) - role of the current user, can be `Administrator`, `Member`, or `Read only`
-      + `indices` (object)
-      + `total` (number) - total number of items in the collection
 
-#### User connections [GET /people/connections]
+### Request information [GET /app_data]
 
-  + Attributes
-
-  + Response 200 (application/json)
++ Request (application/json)
     + Attributes (object)
-      + `id` (string) - user ID
-      + `login` (string) - user login name
-      + `jid` (string) - Jabber/XMPP ID of the user
-      + `mutual_spaces` (array) - array of spaces that are shared by user and space member
-      + `name` (string) - name of the user
-      + `status_message` (string) - status message of the user
+
++ Response 200 (application/json)
+    + Attributes (object)
+        + `self_profile` (object) - profile of current user
+            + `user_id` (string) - ID of current user
+            + `name` (string) - name of current user
+            + `login_name` (string) - login name of current user
+            + `activity_profile` (string) - activity profile of current user
+        + `status_message` (string) - status message for current user
+        + `number_of_connections` (number) - how many current connections are active
+        + `notification` (object)
+            + `item_id` (string) - last received notification item ID
+            + `read_item_it` (string) - last read notification item ID
+
+### Request settings [GET /settings]
+
++ Request (application/json)
+
++ Response 200 (application/json)
+
+### Request spaces [GET /spaces]
+
++ Request (application/json)
+
++ Response 200 (application/json)
+    + Attributes (object)
+        + `id` (number) - space ID
+        + `name` (string) - name of the space
+        + `joined_at` (string) - date of when the user joined the space
+        + `created_at` (string) - date of when the space was created
+        + `owned_roles` (array) - array of objects representing a space role related to the space
+        + `access` (string) - options
+        + `active` (boolean) - whether the space is active or not
+        + `owner` (boolean) - whether the user is the owner of the space
+        + `role_name` (string) - role of the current user, can be `Administrator`, `Member`, or `Read only`
+        + `description` (string) - description of the space
+        + `members_count` (number) - number of members in the space
+        + `visibility` (string) - visibility of the space, can be `visible`, `visible_name`, or `invisible`
+
+### Request space members [GET /spaces/:id/members]
+
++ Request (application/json)
+    + Attributes (object)
+        + `id` (string, required) - UUID of space
+
++ Response 200 (application/json)
+    + Attributes (object)
+        + `id` (string) - user ID
+        + `connected` (boolean) - if the user is connected or not
+        + `mutual_spaces` (array) - array of spaces that are shared by user and space member
+        + `owner` (boolean) - whether user is owner of space or not
+        + `admin` (boolean) - whether user has administrator access to space
+        + `role_name_in_space` (string) - role of the current user, can be `Administrator`, `Member`, or `Read only`
+        + `indices` (object)
+        + `total` (number) - total number of items in the collection
+
+### User connections [GET /people/connections]
+
++ Request (application/json)
+
++ Response 200 (application/json)
+    + Attributes (object)
+        + `id` (string) - user ID
+        + `login` (string) - user login name
+        + `jid` (string) - Jabber/XMPP ID of the user
+        + `mutual_spaces` (array) - array of spaces that are shared by user and space member
+        + `name` (string) - name of the user
+        + `status_message` (string) - status message of the user

--- a/sections/user_creation.apib
+++ b/sections/user_creation.apib
@@ -1,38 +1,36 @@
-## User
+## Group User Creation
 
-### User Creation API
+### Check email uniqueness [GET /signup_validation/check_user_field_uniqueness]
 
-#### Check email uniqueness [GET /signup_validation/check_user_field_uniqueness]
-
-  + Attributes
-    + `email` (string, required) - email address of user
-
-  + Response 200 (application/json)
++ request (application/json)
     + Attributes (object)
-      + `unique` (boolean)
+        + `email` (string, required) - email address of user
 
-#### Create sign-up request [POST /signup_requests]
++ Response 200 (application/json)
+    + Attributes (object)
+        + `unique` (boolean)
 
-  + Attributes
-    + `email` (string, required) - email address of user
+### Create sign-up request [POST /signup_requests]
 
-  + Response 200 (application/json)
-    + Attributes
++ request (application/json)
+    + Attributes (object)
+        + `email` (string, required) - email address of user
 
-  + Response 422 (application/json)
-    + Attributes
++ Response 200 (application/json)
 
-#### Submit sign-up details [POST /signup.user]
++ Response 422 (application/json)
 
-  + Attributes
-    + `email` (string, required) - email address of user
-    + `otp` (string, required) - OTP value from confirmation email
-    + `password` (string, required) - string of new password
+### Submit sign-up details [POST /signup.user]
 
-  + Response 201 (application/json)
-    + Attributes(object)
-      + `id` (string) - ID of new user
-      + `name` (string) - username
++ request (application/json)
+    + Attributes (object)
+        + `email` (string, required) - email address of user
+        + `otp` (string, required) - OTP value from confirmation email
+        + `password` (string, required) - string of new password
 
-  + Response 422 (application/json)
-    + Attributes
++ Response 201 (application/json)
+    + Attributes (object)
+        + `id` (string) - ID of new user
+        + `name` (string) - username
+
++ Response 422 (application/json)


### PR DESCRIPTION
This PR aims to fix several problems introduced in recent commits, namely, it:

- uses the 'unix' line endings instead of 'dos'
- moves `common_ds.apib` back to the top section to bring back `Data Structures`
- uses the `Group` directive for each section
- uses 4-space indentation as per convention
- uses `Request` heading explicitly
- uses the correct syntax for API blueprint for specifying URL parameters
- doesn't confound URL parameters with request attributes
- extracts `File` and `FileVersion` data structures for DRYing purposes
- fixes structure for nested request attributes
- uses the more specific data types for object IDs, datetime strings, enums, etc.
- aligns File API documentation to the one in the [riboseinc Github wiki](https://github.com/riboseinc/ribose-api/wiki/Ribose-File-API-Guide)

