### PR TITLE
Fix URL param specification for Mass Creating of Space Invitations

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2951,7 +2951,10 @@ This is the Ribose API.
 
 + Response 422 (application/json)
 
-#### Mass creating [POST /spaces/:space_id/invitations/to_space/mass_create]
+#### Mass creating [POST /spaces/{space_id}/invitations/to_space/mass_create]
+
++ Parameters
+    + `space_id` (uuid) - UUID of the Space under which invitations are to be created
 
 + Request (application/json)
 

--- a/sections/invitation.apib
+++ b/sections/invitation.apib
@@ -320,7 +320,10 @@
 
 + Response 422 (application/json)
 
-#### Mass creating [POST /spaces/:space_id/invitations/to_space/mass_create]
+#### Mass creating [POST /spaces/{space_id}/invitations/to_space/mass_create]
+
++ Parameters
+    + `space_id` (uuid) - UUID of the Space under which invitations are to be created
 
 + Request (application/json)
 


### PR DESCRIPTION
A wild colon appears !

@ribose-jeffreylau uses Fix !

It's super-effective !