### PR TITLE
Blueprints validator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Ribose's custom additions
+
+/node_modules/
+/package-lock.json
 
 # Created by https://www.gitignore.io/api/vim,linux,macos,emacs,windows,sublimetext
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+sudo: false
+dist: trusty
+
+before_script:
+  - npm install colors drafter.js glob
+
+script:
+  - node validate.js

--- a/validate.js
+++ b/validate.js
@@ -1,0 +1,69 @@
+/* jshint esversion: 6, asi: true */
+/* globals require, process */
+
+let colors = require("colors")
+let drafter = require("drafter.js")
+let fs = require("fs")
+let glob = require("glob")
+let util = require("util")
+
+// Files to validate. Globs like **/*.apib are supported here.
+let patterns = ["apiary.apib"]
+
+function main() {
+  let files = [].concat(...patterns.map((p) => glob.sync(p, {strict: true})))
+  let errs = files.reduce(((acc, f) => validateFile(f) + acc ), 0)
+
+  if (errs > 0) {
+    print("There were %d errors or warnings in %d files.\n", errs, files.length)
+  } else {
+    print("All ok in %d files.\n", errs, files.length)
+  }
+
+  process.exit(errs > 0 ? 1 : 0)
+}
+
+function validateFile(path) {
+  print("Checking %s… ", path)
+  let apib = fs.readFileSync(path, "utf8")
+  let result = drafter.validateSync(apib)
+
+  if (result) {
+    print("FAIL\n".red.bold)
+    printErrors(apib, result)
+  } else {
+    print("OK\n".green)
+  }
+
+  return result ? result.content.length : 0
+}
+
+function printErrors(apib, parseResult) {
+  parseResult.content.forEach(function(problem) {
+    let isError = problem.meta.classes.includes("error")
+    let severityStr = isError ? "error".yellow : "warning".magenta
+    let code = problem.attributes.code
+    let description = problem.content
+    let location = problem.attributes.sourceMap[0].content[0]
+    let line = countNewlines(apib.substr(0, location[0]) + 1)
+    let problemStr = apib.substr(...location).trimRight()
+    print("  %s code %d in line %d - %s:\n", severityStr, code, line, description)
+    print("%s\n", indent(problemStr, "    "))
+  })
+}
+
+function print(string, ...interpolations) {
+  let formatted = util.format(string, ...interpolations)
+  process.stdout.write(formatted)
+}
+
+function indent(string, indentation) {
+  return string.replace(/^(?=.)/gm, indentation)
+}
+
+function countNewlines(string) {
+  let match = string.match(/\n/g) || []
+  return match.length
+}
+
+main()


### PR DESCRIPTION
This is an initial version of Drafter-based validator. Comments are welcome.

1. I had troubles with compiling a C-based variant of Drafter, therefore I've decided to use Drafter.js, its Emscripten-powered JavaScript counterpart.
2. Validator reports plenty of errors for our current blueprints. Maybe it's worth to ignore some error types. Here is the output: https://gist.github.com/skalee/a66ab5953373022d1a41e32060816df1.
3. All reusable component (like https://github.com/riboseinc/ribose-api/blob/master/sections/profile/profile.apib) do not pass because they aren't meant to be complete documents. Perhaps we should skip them when validating.
4. In order to run the validator, install Node.js and do following:
```
$ npm install colors drafter.js glob
$ node validator.js
```

Fixes #33.