### PR TITLE
Improve Travis checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,5 @@ before_script:
 
 script:
   - make HERCULE=./node_modules/hercule/bin/hercule
+  - bash .travis_ensure_compiled.sh
   - node validate.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ sudo: false
 dist: trusty
 
 before_script:
-  - npm install colors drafter.js glob
+  - npm install colors drafter.js glob hercule
 
 script:
+  - make HERCULE=./node_modules/hercule/bin/hercule
   - node validate.js

--- a/.travis_ensure_compiled.sh
+++ b/.travis_ensure_compiled.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [[ $(git status --short) ]]
+then
+  echo "$(tput setaf 3)$(tput setab 1)$(tput bold)"\
+    '!!! Apiary.apib is outdated, compile it before merging !!!'\
+    "$(tput sgr 0)"
+  exit 1
+fi


### PR DESCRIPTION
* Fail builds if `apiary.apib` is outdated.
* That said, always rebuild `apiary.apib` before validating it.