### PR TITLE
Migrate spaces API docs from wiki

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -189,18 +189,26 @@ This is the Ribose API.
 
 ### Space (object)
 
-+ `id` (number) - space ID
++ `id` (uuid) - space ID
 + `name` (string) - name of the space
-+ `joined_at` (string) - date of when the user joined the space
-+ `created_at` (string) - date of when the space was created
++ `joined_at` (DatetimeString) - date of when the user joined the space
++ `created_at` (DatetimeString) - date of when the space was created
 + `owned_roles` (array) - array of objects representing a space role related to the space
 + `access` (string) - options
 + `active` (boolean) - whether the space is active or not
 + `owner` (boolean) - whether the user is the owner of the space
-+ `role_name` (string) - role of the current user, can be `Administrator`, `Member`, or `Read only`
++ `role_name` (string) - role of the current user
+    * Members
+        * Administrator
+        * Member
+        * Read only
 + `description` (string) - description of the space
 + `members_count` (number) - number of members in the space
-+ `visibility` (string) - visibility of the space, can be `visible`, `visible_name`, or `invisible`
++ `visibility` (enum[string]) - visibility of the space
+    * Members
+        * visible
+        * visible_name
+        * invisible
 
 ### User (object)
 
@@ -3665,7 +3673,7 @@ Updates and returns the updated setting object of the given id if the user owns 
 #### Show [GET /spaces/{space_id}]
 
 + Parameters
-    + `space_id` (id)
+    + `space_id` (uuid)
 
 + Request (application/json)
 
@@ -3738,7 +3746,7 @@ Updates and returns the updated setting object of the given id if the user owns 
 #### Update [PUT /spaces/{space_id}]
 
 + Parameters
-    + `space_id` (id)
+    + `space_id` (uuid)
 
 + Request (application/json)
     + Attributes (object)
@@ -3813,7 +3821,7 @@ Updates and returns the updated setting object of the given id if the user owns 
 #### Delete [DELETE /spaces/{space_id}]
 
 + Parameters
-    + `space_id` (id)
+    + `space_id` (uuid)
 
 + Request (application/json)
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -3539,7 +3539,7 @@ Updates and returns the updated setting object of the given id if the user owns 
             {
               "spaces":[
                 {
-                  "id":"123456789",
+                  "id":"0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
                   "name":"Work",
                   "created_at": "2017-07-27T07:19:09.000+00:00",
                   "invite_access":"admins",

--- a/apiary.apib
+++ b/apiary.apib
@@ -3523,7 +3523,8 @@ Updates and returns the updated setting object of the given id if the user owns 
 + Request (application/json)
 
 + Response 200 (application/json)
-    + Attributes (Space)
+    + Attributes (object)
+        + spaces (array[Space]) - list of spaces
 ## Group Space Member
 
 ### Space Members [/spaces/{space_id}/members]

--- a/apiary.apib
+++ b/apiary.apib
@@ -3526,6 +3526,70 @@ Updates and returns the updated setting object of the given id if the user owns 
     + Attributes (object)
         + spaces (array[Space]) - list of spaces
 
+    + Body
+
+            {
+              "spaces":[
+                {
+                  "id":"123456789",
+                  "name":"Work",
+                  "created_at": "2017-07-27T07:19:09.000+00:00",
+                  "invite_access":"admins",
+                  "space_category_id":null,
+                  "visibility":"invisible",
+                  "group_email":"work57",
+                  "default_role_id":41592,
+                  "join_requests_access":"disabled",
+                  "active":true,
+                  "description":"Client work related discussion",
+                  "members_count":1,
+                  "admin":true,
+                  "invitable_roles":[
+                    {
+                      "id":41592,
+                      "name":"Member",
+                      "space_id":"123456789"
+                    },
+                    {
+                      "id":41593,
+                      "name":"Administrator",
+                      "space_id":"123456789"
+                    },
+                    {
+                      "id":41594,
+                      "name":"Read only",
+                      "space_id":"123456789"
+                    }
+                  ],
+                  "owner":true,
+                  "read_only":false,
+                  "role_name":"Administrator",
+                  "allow_invite":true,
+                  "joined_at": "2017-07-27T07:19:09.000+00:00",
+                  "access":"private",
+                  "publishable?":false,
+                  "user":{
+                    "id":"63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+                    "name":"Abu Nashir"
+                  },
+                  "owned_roles":[
+                    {
+                      "id":41592,
+                      "name":"Member"
+                    },
+                    {
+                      "id":41593,
+                      "name":"Administrator"
+                    },
+                    {
+                      "id":41594,
+                      "name":"Read only"
+                    }
+                  ]
+                }
+              ]
+            }
+
 #### Create [POST]
 
 + Request (application/json)
@@ -3535,6 +3599,68 @@ Updates and returns the updated setting object of the given id if the user owns 
 + Response 200 (application/json)
     + Attributes (object)
         + space (Space) - created space
+
+    + Body
+
+            {
+              "space": {
+                "id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+                "name": "Work",
+                "created_at": "2017-07-27T07:19:09.000+00:00",
+                "invite_access": "admins",
+                "space_category_id": null,
+                "visibility": "invisible",
+                "group_email": "work57",
+                "default_role_id": 41592,
+                "join_requests_access": "disabled",
+                "active": true,
+                "description": "Client work related discussion",
+                "members_count": 1,
+                "admin": true,
+                "invitable_roles": [
+                  {
+                    "id": 41592,
+                    "name": "Member",
+                    "space_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+                  },
+                  {
+                    "id": 41593,
+                    "name": "Administrator",
+                    "space_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+                  },
+                  {
+                    "id": 41594,
+                    "name": "Read only",
+                    "space_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+                  }
+                ],
+                "owner": true,
+                "read_only": false,
+                "role_name": "Administrator",
+                "allow_invite": true,
+                "joined_at": "2017-07-27T07:19:09.000+00:00",
+                "access": "private",
+                "publishable?": false,
+                "user": {
+                  "id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+                  "name": "John Doe"
+                },
+                "owned_roles": [
+                  {
+                    "id": 41592,
+                    "name": "Member"
+                  },
+                  {
+                    "id": 41593,
+                    "name": "Administrator"
+                  },
+                  {
+                    "id": 41594,
+                    "name": "Read only"
+                  }
+                ]
+              }
+            }
 
 #### Show [GET /spaces/{space_id}]
 
@@ -3546,6 +3672,68 @@ Updates and returns the updated setting object of the given id if the user owns 
 + Response 200 (application/json)
     + Attributes (object)
         + space (Space) - retrieved space
+
+    + Body
+
+            {
+              "space": {
+                "id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+                "name": "Work",
+                "created_at": "2017-07-27T07:19:09.000+00:00",
+                "invite_access": "admins",
+                "space_category_id": null,
+                "visibility": "invisible",
+                "group_email": "work57",
+                "default_role_id": 41592,
+                "join_requests_access": "disabled",
+                "active": true,
+                "description": "Client work related discussion",
+                "members_count": 1,
+                "admin": true,
+                "invitable_roles": [
+                  {
+                    "id": 41592,
+                    "name": "Member",
+                    "space_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+                  },
+                  {
+                    "id": 41593,
+                    "name": "Administrator",
+                    "space_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+                  },
+                  {
+                    "id": 41594,
+                    "name": "Read only",
+                    "space_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+                  }
+                ],
+                "owner": true,
+                "read_only": false,
+                "role_name": "Administrator",
+                "allow_invite": true,
+                "joined_at": "2017-07-27T07:19:09.000+00:00",
+                "access": "private",
+                "publishable?": false,
+                "user": {
+                  "id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+                  "name": "John Doe"
+                },
+                "owned_roles": [
+                  {
+                    "id": 41592,
+                    "name": "Member"
+                  },
+                  {
+                    "id": 41593,
+                    "name": "Administrator"
+                  },
+                  {
+                    "id": 41594,
+                    "name": "Read only"
+                  }
+                ]
+              }
+            }
 
 #### Update [PUT /spaces/{space_id}]
 
@@ -3559,6 +3747,68 @@ Updates and returns the updated setting object of the given id if the user owns 
 + Response 200 (application/json)
     + Attributes (object)
         + space (Space) - updated space
+
+    + Body
+
+            {
+              "space": {
+                "id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+                "name": "Work",
+                "created_at": "2017-07-27T07:19:09.000+00:00",
+                "invite_access": "admins",
+                "space_category_id": null,
+                "visibility": "invisible",
+                "group_email": "work57",
+                "default_role_id": 41592,
+                "join_requests_access": "disabled",
+                "active": true,
+                "description": "Client work related discussion",
+                "members_count": 1,
+                "admin": true,
+                "invitable_roles": [
+                  {
+                    "id": 41592,
+                    "name": "Member",
+                    "space_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+                  },
+                  {
+                    "id": 41593,
+                    "name": "Administrator",
+                    "space_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+                  },
+                  {
+                    "id": 41594,
+                    "name": "Read only",
+                    "space_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+                  }
+                ],
+                "owner": true,
+                "read_only": false,
+                "role_name": "Administrator",
+                "allow_invite": true,
+                "joined_at": "2017-07-27T07:19:09.000+00:00",
+                "access": "private",
+                "publishable?": false,
+                "user": {
+                  "id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+                  "name": "John Doe"
+                },
+                "owned_roles": [
+                  {
+                    "id": 41592,
+                    "name": "Member"
+                  },
+                  {
+                    "id": 41593,
+                    "name": "Administrator"
+                  },
+                  {
+                    "id": 41594,
+                    "name": "Read only"
+                  }
+                ]
+              }
+            }
 
 #### Delete [DELETE /spaces/{space_id}]
 

--- a/apiary.apib
+++ b/apiary.apib
@@ -176,7 +176,7 @@ This is the Ribose API.
 + `updated_at` (DatetimeString) - when the file version was updated
 + `version` (number) - version number of the file
 
-### Space (object)
+### SimpleSpace (object)
 
 * `id`: 948AD10F-B2A2-4DDC-9AC7-E766E4586A20 (uuid)
 * `name`: My first space (string) - Space name
@@ -395,7 +395,7 @@ This is the Ribose API.
                 + `points_till_next_level`: 1187255 (number)
                 + `points_for_current_level`: 1457750 (number)
             + `mutual_users` (array[uuid]) - list of connected Users's UUID
-            + `visible_spaces` (array[Space]) - list of current User's Spaces
+            + `visible_spaces` (array[SimpleSpace]) - list of current User's Spaces
             + `connection_id`: null (uuid, nullable)
             + `from_ribose?`: true (boolean, fixed)
             + `name`: Joe Public (string)

--- a/apiary.apib
+++ b/apiary.apib
@@ -197,25 +197,6 @@ This is the Ribose API.
 
 ## Group General
 
-### Request spaces [GET /spaces]
-
-+ Request (application/json)
-
-+ Response 200 (application/json)
-    + Attributes (object)
-        + `id` (number) - space ID
-        + `name` (string) - name of the space
-        + `joined_at` (string) - date of when the user joined the space
-        + `created_at` (string) - date of when the space was created
-        + `owned_roles` (array) - array of objects representing a space role related to the space
-        + `access` (string) - options
-        + `active` (boolean) - whether the space is active or not
-        + `owner` (boolean) - whether the user is the owner of the space
-        + `role_name` (string) - role of the current user, can be `Administrator`, `Member`, or `Read only`
-        + `description` (string) - description of the space
-        + `members_count` (number) - number of members in the space
-        + `visibility` (string) - visibility of the space, can be `visible`, `visible_name`, or `invisible`
-
 ### User connections [GET /people/connections]
 
 + Request (application/json)
@@ -3518,7 +3499,28 @@ Updates and returns the updated setting object of the given id if the user owns 
             "realtime_notifications":false
           }
         }
+## Group Space
 
+### Spaces [/spaces]
+
+#### Index [GET]
+
++ Request (application/json)
+
++ Response 200 (application/json)
+    + Attributes (object)
+        + `id` (number) - space ID
+        + `name` (string) - name of the space
+        + `joined_at` (string) - date of when the user joined the space
+        + `created_at` (string) - date of when the space was created
+        + `owned_roles` (array) - array of objects representing a space role related to the space
+        + `access` (string) - options
+        + `active` (boolean) - whether the space is active or not
+        + `owner` (boolean) - whether the user is the owner of the space
+        + `role_name` (string) - role of the current user, can be `Administrator`, `Member`, or `Read only`
+        + `description` (string) - description of the space
+        + `members_count` (number) - number of members in the space
+        + `visibility` (string) - visibility of the space, can be `visible`, `visible_name`, or `invisible`
 ## Group Space Member
 
 ### Space Members [/spaces/{space_id}/members]

--- a/apiary.apib
+++ b/apiary.apib
@@ -3525,6 +3525,49 @@ Updates and returns the updated setting object of the given id if the user owns 
 + Response 200 (application/json)
     + Attributes (object)
         + spaces (array[Space]) - list of spaces
+
+#### Create [POST]
+
++ Request (application/json)
+    + Attributes (object)
+        + space (Space) - new space attributes
+
++ Response 200 (application/json)
+    + Attributes (object)
+        + space (Space) - created space
+
+#### Show [GET /spaces/{space_id}]
+
++ Parameters
+    + `space_id` (id)
+
++ Request (application/json)
+
++ Response 200 (application/json)
+    + Attributes (object)
+        + space (Space) - retrieved space
+
+#### Update [PUT /spaces/{space_id}]
+
++ Parameters
+    + `space_id` (id)
+
++ Request (application/json)
+    + Attributes (object)
+        + space (Space) - space update
+
++ Response 200 (application/json)
+    + Attributes (object)
+        + space (Space) - updated space
+
+#### Delete [DELETE /spaces/{space_id}]
+
++ Parameters
+    + `space_id` (id)
+
++ Request (application/json)
+
++ Response 200 (application/json)
 ## Group Space Member
 
 ### Space Members [/spaces/{space_id}/members]

--- a/apiary.apib
+++ b/apiary.apib
@@ -187,6 +187,21 @@ This is the Ribose API.
         * invisible
 * `members_count`: 10 (number) - how many members it contains
 
+### Space (object)
+
++ `id` (number) - space ID
++ `name` (string) - name of the space
++ `joined_at` (string) - date of when the user joined the space
++ `created_at` (string) - date of when the space was created
++ `owned_roles` (array) - array of objects representing a space role related to the space
++ `access` (string) - options
++ `active` (boolean) - whether the space is active or not
++ `owner` (boolean) - whether the user is the owner of the space
++ `role_name` (string) - role of the current user, can be `Administrator`, `Member`, or `Read only`
++ `description` (string) - description of the space
++ `members_count` (number) - number of members in the space
++ `visibility` (string) - visibility of the space, can be `visible`, `visible_name`, or `invisible`
+
 ### User (object)
 
 * `id`: 109EF27E-B8BD-4CAC-9DC5-4F00BD2444ED (uuid)
@@ -3508,19 +3523,7 @@ Updates and returns the updated setting object of the given id if the user owns 
 + Request (application/json)
 
 + Response 200 (application/json)
-    + Attributes (object)
-        + `id` (number) - space ID
-        + `name` (string) - name of the space
-        + `joined_at` (string) - date of when the user joined the space
-        + `created_at` (string) - date of when the space was created
-        + `owned_roles` (array) - array of objects representing a space role related to the space
-        + `access` (string) - options
-        + `active` (boolean) - whether the space is active or not
-        + `owner` (boolean) - whether the user is the owner of the space
-        + `role_name` (string) - role of the current user, can be `Administrator`, `Member`, or `Read only`
-        + `description` (string) - description of the space
-        + `members_count` (number) - number of members in the space
-        + `visibility` (string) - visibility of the space, can be `visible`, `visible_name`, or `invisible`
+    + Attributes (Space)
 ## Group Space Member
 
 ### Space Members [/spaces/{space_id}/members]

--- a/sections/app_data.apib
+++ b/sections/app_data.apib
@@ -80,7 +80,7 @@
                 + `points_till_next_level`: 1187255 (number)
                 + `points_for_current_level`: 1457750 (number)
             + `mutual_users` (array[uuid]) - list of connected Users's UUID
-            + `visible_spaces` (array[Space]) - list of current User's Spaces
+            + `visible_spaces` (array[SimpleSpace]) - list of current User's Spaces
             + `connection_id`: null (uuid, nullable)
             + `from_ribose?`: true (boolean, fixed)
             + `name`: Joe Public (string)

--- a/sections/common_ds.apib
+++ b/sections/common_ds.apib
@@ -174,6 +174,21 @@
         * invisible
 * `members_count`: 10 (number) - how many members it contains
 
+### Space (object)
+
++ `id` (number) - space ID
++ `name` (string) - name of the space
++ `joined_at` (string) - date of when the user joined the space
++ `created_at` (string) - date of when the space was created
++ `owned_roles` (array) - array of objects representing a space role related to the space
++ `access` (string) - options
++ `active` (boolean) - whether the space is active or not
++ `owner` (boolean) - whether the user is the owner of the space
++ `role_name` (string) - role of the current user, can be `Administrator`, `Member`, or `Read only`
++ `description` (string) - description of the space
++ `members_count` (number) - number of members in the space
++ `visibility` (string) - visibility of the space, can be `visible`, `visible_name`, or `invisible`
+
 ### User (object)
 
 * `id`: 109EF27E-B8BD-4CAC-9DC5-4F00BD2444ED (uuid)

--- a/sections/common_ds.apib
+++ b/sections/common_ds.apib
@@ -163,7 +163,7 @@
 + `updated_at` (DatetimeString) - when the file version was updated
 + `version` (number) - version number of the file
 
-### Space (object)
+### SimpleSpace (object)
 
 * `id`: 948AD10F-B2A2-4DDC-9AC7-E766E4586A20 (uuid)
 * `name`: My first space (string) - Space name

--- a/sections/common_ds.apib
+++ b/sections/common_ds.apib
@@ -176,18 +176,26 @@
 
 ### Space (object)
 
-+ `id` (number) - space ID
++ `id` (uuid) - space ID
 + `name` (string) - name of the space
-+ `joined_at` (string) - date of when the user joined the space
-+ `created_at` (string) - date of when the space was created
++ `joined_at` (DatetimeString) - date of when the user joined the space
++ `created_at` (DatetimeString) - date of when the space was created
 + `owned_roles` (array) - array of objects representing a space role related to the space
 + `access` (string) - options
 + `active` (boolean) - whether the space is active or not
 + `owner` (boolean) - whether the user is the owner of the space
-+ `role_name` (string) - role of the current user, can be `Administrator`, `Member`, or `Read only`
++ `role_name` (string) - role of the current user
+    * Members
+        * Administrator
+        * Member
+        * Read only
 + `description` (string) - description of the space
 + `members_count` (number) - number of members in the space
-+ `visibility` (string) - visibility of the space, can be `visible`, `visible_name`, or `invisible`
++ `visibility` (enum[string]) - visibility of the space
+    * Members
+        * visible
+        * visible_name
+        * invisible
 
 ### User (object)
 

--- a/sections/general.apib
+++ b/sections/general.apib
@@ -1,24 +1,5 @@
 ## Group General
 
-### Request spaces [GET /spaces]
-
-+ Request (application/json)
-
-+ Response 200 (application/json)
-    + Attributes (object)
-        + `id` (number) - space ID
-        + `name` (string) - name of the space
-        + `joined_at` (string) - date of when the user joined the space
-        + `created_at` (string) - date of when the space was created
-        + `owned_roles` (array) - array of objects representing a space role related to the space
-        + `access` (string) - options
-        + `active` (boolean) - whether the space is active or not
-        + `owner` (boolean) - whether the user is the owner of the space
-        + `role_name` (string) - role of the current user, can be `Administrator`, `Member`, or `Read only`
-        + `description` (string) - description of the space
-        + `members_count` (number) - number of members in the space
-        + `visibility` (string) - visibility of the space, can be `visible`, `visible_name`, or `invisible`
-
 ### User connections [GET /people/connections]
 
 + Request (application/json)

--- a/sections/space.apib
+++ b/sections/space.apib
@@ -15,7 +15,7 @@
             {
               "spaces":[
                 {
-                  "id":"123456789",
+                  "id":"0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
                   "name":"Work",
                   "created_at": "2017-07-27T07:19:09.000+00:00",
                   "invite_access":"admins",

--- a/sections/space.apib
+++ b/sections/space.apib
@@ -1,0 +1,22 @@
+## Group Space
+
+### Spaces [/spaces]
+
+#### Index [GET]
+
++ Request (application/json)
+
++ Response 200 (application/json)
+    + Attributes (object)
+        + `id` (number) - space ID
+        + `name` (string) - name of the space
+        + `joined_at` (string) - date of when the user joined the space
+        + `created_at` (string) - date of when the space was created
+        + `owned_roles` (array) - array of objects representing a space role related to the space
+        + `access` (string) - options
+        + `active` (boolean) - whether the space is active or not
+        + `owner` (boolean) - whether the user is the owner of the space
+        + `role_name` (string) - role of the current user, can be `Administrator`, `Member`, or `Read only`
+        + `description` (string) - description of the space
+        + `members_count` (number) - number of members in the space
+        + `visibility` (string) - visibility of the space, can be `visible`, `visible_name`, or `invisible`

--- a/sections/space.apib
+++ b/sections/space.apib
@@ -7,4 +7,5 @@
 + Request (application/json)
 
 + Response 200 (application/json)
-    + Attributes (Space)
+    + Attributes (object)
+        + spaces (array[Space]) - list of spaces

--- a/sections/space.apib
+++ b/sections/space.apib
@@ -9,3 +9,46 @@
 + Response 200 (application/json)
     + Attributes (object)
         + spaces (array[Space]) - list of spaces
+
+#### Create [POST]
+
++ Request (application/json)
+    + Attributes (object)
+        + space (Space) - new space attributes
+
++ Response 200 (application/json)
+    + Attributes (object)
+        + space (Space) - created space
+
+#### Show [GET /spaces/{space_id}]
+
++ Parameters
+    + `space_id` (id)
+
++ Request (application/json)
+
++ Response 200 (application/json)
+    + Attributes (object)
+        + space (Space) - retrieved space
+
+#### Update [PUT /spaces/{space_id}]
+
++ Parameters
+    + `space_id` (id)
+
++ Request (application/json)
+    + Attributes (object)
+        + space (Space) - space update
+
++ Response 200 (application/json)
+    + Attributes (object)
+        + space (Space) - updated space
+
+#### Delete [DELETE /spaces/{space_id}]
+
++ Parameters
+    + `space_id` (id)
+
++ Request (application/json)
+
++ Response 200 (application/json)

--- a/sections/space.apib
+++ b/sections/space.apib
@@ -10,6 +10,70 @@
     + Attributes (object)
         + spaces (array[Space]) - list of spaces
 
+    + Body
+
+            {
+              "spaces":[
+                {
+                  "id":"123456789",
+                  "name":"Work",
+                  "created_at": "2017-07-27T07:19:09.000+00:00",
+                  "invite_access":"admins",
+                  "space_category_id":null,
+                  "visibility":"invisible",
+                  "group_email":"work57",
+                  "default_role_id":41592,
+                  "join_requests_access":"disabled",
+                  "active":true,
+                  "description":"Client work related discussion",
+                  "members_count":1,
+                  "admin":true,
+                  "invitable_roles":[
+                    {
+                      "id":41592,
+                      "name":"Member",
+                      "space_id":"123456789"
+                    },
+                    {
+                      "id":41593,
+                      "name":"Administrator",
+                      "space_id":"123456789"
+                    },
+                    {
+                      "id":41594,
+                      "name":"Read only",
+                      "space_id":"123456789"
+                    }
+                  ],
+                  "owner":true,
+                  "read_only":false,
+                  "role_name":"Administrator",
+                  "allow_invite":true,
+                  "joined_at": "2017-07-27T07:19:09.000+00:00",
+                  "access":"private",
+                  "publishable?":false,
+                  "user":{
+                    "id":"63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+                    "name":"Abu Nashir"
+                  },
+                  "owned_roles":[
+                    {
+                      "id":41592,
+                      "name":"Member"
+                    },
+                    {
+                      "id":41593,
+                      "name":"Administrator"
+                    },
+                    {
+                      "id":41594,
+                      "name":"Read only"
+                    }
+                  ]
+                }
+              ]
+            }
+
 #### Create [POST]
 
 + Request (application/json)
@@ -19,6 +83,68 @@
 + Response 200 (application/json)
     + Attributes (object)
         + space (Space) - created space
+
+    + Body
+
+            {
+              "space": {
+                "id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+                "name": "Work",
+                "created_at": "2017-07-27T07:19:09.000+00:00",
+                "invite_access": "admins",
+                "space_category_id": null,
+                "visibility": "invisible",
+                "group_email": "work57",
+                "default_role_id": 41592,
+                "join_requests_access": "disabled",
+                "active": true,
+                "description": "Client work related discussion",
+                "members_count": 1,
+                "admin": true,
+                "invitable_roles": [
+                  {
+                    "id": 41592,
+                    "name": "Member",
+                    "space_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+                  },
+                  {
+                    "id": 41593,
+                    "name": "Administrator",
+                    "space_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+                  },
+                  {
+                    "id": 41594,
+                    "name": "Read only",
+                    "space_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+                  }
+                ],
+                "owner": true,
+                "read_only": false,
+                "role_name": "Administrator",
+                "allow_invite": true,
+                "joined_at": "2017-07-27T07:19:09.000+00:00",
+                "access": "private",
+                "publishable?": false,
+                "user": {
+                  "id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+                  "name": "John Doe"
+                },
+                "owned_roles": [
+                  {
+                    "id": 41592,
+                    "name": "Member"
+                  },
+                  {
+                    "id": 41593,
+                    "name": "Administrator"
+                  },
+                  {
+                    "id": 41594,
+                    "name": "Read only"
+                  }
+                ]
+              }
+            }
 
 #### Show [GET /spaces/{space_id}]
 
@@ -30,6 +156,68 @@
 + Response 200 (application/json)
     + Attributes (object)
         + space (Space) - retrieved space
+
+    + Body
+
+            {
+              "space": {
+                "id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+                "name": "Work",
+                "created_at": "2017-07-27T07:19:09.000+00:00",
+                "invite_access": "admins",
+                "space_category_id": null,
+                "visibility": "invisible",
+                "group_email": "work57",
+                "default_role_id": 41592,
+                "join_requests_access": "disabled",
+                "active": true,
+                "description": "Client work related discussion",
+                "members_count": 1,
+                "admin": true,
+                "invitable_roles": [
+                  {
+                    "id": 41592,
+                    "name": "Member",
+                    "space_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+                  },
+                  {
+                    "id": 41593,
+                    "name": "Administrator",
+                    "space_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+                  },
+                  {
+                    "id": 41594,
+                    "name": "Read only",
+                    "space_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+                  }
+                ],
+                "owner": true,
+                "read_only": false,
+                "role_name": "Administrator",
+                "allow_invite": true,
+                "joined_at": "2017-07-27T07:19:09.000+00:00",
+                "access": "private",
+                "publishable?": false,
+                "user": {
+                  "id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+                  "name": "John Doe"
+                },
+                "owned_roles": [
+                  {
+                    "id": 41592,
+                    "name": "Member"
+                  },
+                  {
+                    "id": 41593,
+                    "name": "Administrator"
+                  },
+                  {
+                    "id": 41594,
+                    "name": "Read only"
+                  }
+                ]
+              }
+            }
 
 #### Update [PUT /spaces/{space_id}]
 
@@ -43,6 +231,68 @@
 + Response 200 (application/json)
     + Attributes (object)
         + space (Space) - updated space
+
+    + Body
+
+            {
+              "space": {
+                "id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc",
+                "name": "Work",
+                "created_at": "2017-07-27T07:19:09.000+00:00",
+                "invite_access": "admins",
+                "space_category_id": null,
+                "visibility": "invisible",
+                "group_email": "work57",
+                "default_role_id": 41592,
+                "join_requests_access": "disabled",
+                "active": true,
+                "description": "Client work related discussion",
+                "members_count": 1,
+                "admin": true,
+                "invitable_roles": [
+                  {
+                    "id": 41592,
+                    "name": "Member",
+                    "space_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+                  },
+                  {
+                    "id": 41593,
+                    "name": "Administrator",
+                    "space_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+                  },
+                  {
+                    "id": 41594,
+                    "name": "Read only",
+                    "space_id": "0e8d5c16-1a31-4df9-83d9-eeaa374d5adc"
+                  }
+                ],
+                "owner": true,
+                "read_only": false,
+                "role_name": "Administrator",
+                "allow_invite": true,
+                "joined_at": "2017-07-27T07:19:09.000+00:00",
+                "access": "private",
+                "publishable?": false,
+                "user": {
+                  "id": "63116bd1-c08d-4a4d-8332-fcdaecb13e34",
+                  "name": "John Doe"
+                },
+                "owned_roles": [
+                  {
+                    "id": 41592,
+                    "name": "Member"
+                  },
+                  {
+                    "id": 41593,
+                    "name": "Administrator"
+                  },
+                  {
+                    "id": 41594,
+                    "name": "Read only"
+                  }
+                ]
+              }
+            }
 
 #### Delete [DELETE /spaces/{space_id}]
 

--- a/sections/space.apib
+++ b/sections/space.apib
@@ -7,16 +7,4 @@
 + Request (application/json)
 
 + Response 200 (application/json)
-    + Attributes (object)
-        + `id` (number) - space ID
-        + `name` (string) - name of the space
-        + `joined_at` (string) - date of when the user joined the space
-        + `created_at` (string) - date of when the space was created
-        + `owned_roles` (array) - array of objects representing a space role related to the space
-        + `access` (string) - options
-        + `active` (boolean) - whether the space is active or not
-        + `owner` (boolean) - whether the user is the owner of the space
-        + `role_name` (string) - role of the current user, can be `Administrator`, `Member`, or `Read only`
-        + `description` (string) - description of the space
-        + `members_count` (number) - number of members in the space
-        + `visibility` (string) - visibility of the space, can be `visible`, `visible_name`, or `invisible`
+    + Attributes (Space)

--- a/sections/space.apib
+++ b/sections/space.apib
@@ -149,7 +149,7 @@
 #### Show [GET /spaces/{space_id}]
 
 + Parameters
-    + `space_id` (id)
+    + `space_id` (uuid)
 
 + Request (application/json)
 
@@ -222,7 +222,7 @@
 #### Update [PUT /spaces/{space_id}]
 
 + Parameters
-    + `space_id` (id)
+    + `space_id` (uuid)
 
 + Request (application/json)
     + Attributes (object)
@@ -297,7 +297,7 @@
 #### Delete [DELETE /spaces/{space_id}]
 
 + Parameters
-    + `space_id` (id)
+    + `space_id` (uuid)
 
 + Request (application/json)
 


### PR DESCRIPTION
@ribose-jeffreylau There's [space object definition](https://github.com/riboseinc/ribose-api/blob/6e9b2d22cc6b990dd176027a58d3c2f3cb757a58/sections/common_ds.apib#L166-L175) in datatypes section, however it lacks many attributes. Should I enhance and reuse it? Or maybe it's a totally different thing?

Fixes #4.