### PR TITLE
Force apiary.apib rebuild in Travis CI checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ before_script:
   - npm install colors drafter.js glob hercule
 
 script:
-  - make HERCULE=./node_modules/hercule/bin/hercule
+  - make rebuild HERCULE=./node_modules/hercule/bin/hercule
   - bash .travis_ensure_compiled.sh
   - node validate.js

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 DIRS    := sections
 DEPS    := $(foreach dir, $(DIRS), $(wildcard $(dir)/*))
 HERCULE  = hercule
+TARGET   = apiary.apib
 
-apiary.apib: input.apib $(DEPS)
+$(TARGET): input.apib $(DEPS)
 	$(HERCULE) $< -o $@
-

--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,14 @@ DEPS    := $(foreach dir, $(DIRS), $(wildcard $(dir)/*))
 HERCULE  = hercule
 TARGET   = apiary.apib
 
+.PHONY: build clean rebuild
+
 $(TARGET): input.apib $(DEPS)
 	$(HERCULE) $< -o $@
+
+build: $(TARGET)
+
+clean:
+	- rm $(TARGET)
+
+rebuild: clean build


### PR DESCRIPTION
Make relies on file modification timestamps, and when people work concurrently in the project, it's not reliable.  For instance, apiary.apib may be lacking some changes from a source file, and still be newer than that source file because it has been updated in another pull request.

For this reason, always rebuild apiary.apib in Travis before doing other checks.