### PR TITLE
Remove duplicated settings documentation

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -197,12 +197,6 @@ This is the Ribose API.
 
 ## Group General
 
-### Request settings [GET /settings]
-
-+ Request (application/json)
-
-+ Response 200 (application/json)
-
 ### Request spaces [GET /spaces]
 
 + Request (application/json)

--- a/sections/general.apib
+++ b/sections/general.apib
@@ -1,11 +1,5 @@
 ## Group General
 
-### Request settings [GET /settings]
-
-+ Request (application/json)
-
-+ Response 200 (application/json)
-
 ### Request spaces [GET /spaces]
 
 + Request (application/json)


### PR DESCRIPTION
Action GET /settings is documented in sections/setting.apib. I believe that entry in `sections/general.apib` is invalid, and should be removed. However, it may be similar case to #37, where an endpoint is used in two different contexts, and has two different meanings. Therefore, @ribose-jeffreylau, please review it before merging.

Fixes #38.