### PR TITLE
Fix attribute data type in Space definition

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -197,7 +197,7 @@ This is the Ribose API.
 + `access` (string) - options
 + `active` (boolean) - whether the space is active or not
 + `owner` (boolean) - whether the user is the owner of the space
-+ `role_name` (string) - role of the current user
++ `role_name` (enum[string]) - role of the current user
     * Members
         * Administrator
         * Member

--- a/sections/common_ds.apib
+++ b/sections/common_ds.apib
@@ -184,7 +184,7 @@
 + `access` (string) - options
 + `active` (boolean) - whether the space is active or not
 + `owner` (boolean) - whether the user is the owner of the space
-+ `role_name` (string) - role of the current user
++ `role_name` (enum[string]) - role of the current user
     * Members
         * Administrator
         * Member


### PR DESCRIPTION
It should be an enum, obviously. Fixes #52.