### PR TITLE
Do not document actions twice

### DIFF
--- a/apiary.apib
+++ b/apiary.apib
@@ -2855,11 +2855,11 @@ This is the Ribose API.
 
 - Response 422 (application/json)
 
-#### Accepting / Rejecting [PUT]
+#### Updating / Accepting / Rejecting [PUT]
 
-    - an invitee-only action
+- Request Accepting / Rejecting a.k.a Ignoring (application/json)
 
-- Request (application/json)
+    Must be performed by invitee.
 
     - Attributes (object)
         - `invitation` (object)
@@ -2868,18 +2868,15 @@ This is the Ribose API.
                     - 1 - Accepting
                     - 2 - Rejecting (ignoring)
 
-
 - Response 200 (application/json)
 
     - Attributes (object)
 
         - `to_space` (InvitationToSpace)
 
-#### Updating pre-assigned role [PUT /invitations/to_space/{invitation_id}]
+- Request Updating pre-assigned role (application/json)
 
-    - inviter-only action
-
-- Request (application/json)
+    Must be performed by inviter.
 
     - Attributes (object)
 
@@ -2891,7 +2888,6 @@ This is the Ribose API.
     - Attributes (object)
 
         - `to_space` (InvitationToSpace)
-
 
 #### Retrieving [GET /invitations/to_space{?view,start,length,s,order_by,direction}]
 
@@ -2983,11 +2979,11 @@ This is the Ribose API.
     - `invitation_id` (id)
 
 
-#### Accepting / Rejecting a.k.a Ignoring [PUT]
+#### Updating / Accepting / Rejecting [PUT]
 
-    - An invitee-only action
+- Request Accepting / Rejecting a.k.a Ignoring (application/json)
 
-- Request (application/json)
+    Must be performed by invitee.
 
     - Attributes (object)
         - `invitation` (object)
@@ -3002,11 +2998,9 @@ This is the Ribose API.
 
         - `join_space_request` (InvitationToSpace)
 
-#### Updating pre-assigned role [PUT]
+- Request Updating pre-assigned role (application/json)
 
-    - A Space Admin-only action
-
-- Request (application/json)
+    Must be performed by Space Admin.
 
     - Attributes (object)
 

--- a/sections/invitation.apib
+++ b/sections/invitation.apib
@@ -252,11 +252,11 @@
 
 - Response 422 (application/json)
 
-#### Accepting / Rejecting [PUT]
+#### Updating / Accepting / Rejecting [PUT]
 
-    - an invitee-only action
+- Request Accepting / Rejecting a.k.a Ignoring (application/json)
 
-- Request (application/json)
+    Must be performed by invitee.
 
     - Attributes (object)
         - `invitation` (object)
@@ -265,18 +265,15 @@
                     - 1 - Accepting
                     - 2 - Rejecting (ignoring)
 
-
 - Response 200 (application/json)
 
     - Attributes (object)
 
         - `to_space` (InvitationToSpace)
 
-#### Updating pre-assigned role [PUT /invitations/to_space/{invitation_id}]
+- Request Updating pre-assigned role (application/json)
 
-    - inviter-only action
-
-- Request (application/json)
+    Must be performed by inviter.
 
     - Attributes (object)
 
@@ -288,7 +285,6 @@
     - Attributes (object)
 
         - `to_space` (InvitationToSpace)
-
 
 #### Retrieving [GET /invitations/to_space{?view,start,length,s,order_by,direction}]
 
@@ -380,11 +376,11 @@
     - `invitation_id` (id)
 
 
-#### Accepting / Rejecting a.k.a Ignoring [PUT]
+#### Updating / Accepting / Rejecting [PUT]
 
-    - An invitee-only action
+- Request Accepting / Rejecting a.k.a Ignoring (application/json)
 
-- Request (application/json)
+    Must be performed by invitee.
 
     - Attributes (object)
         - `invitation` (object)
@@ -399,11 +395,9 @@
 
         - `join_space_request` (InvitationToSpace)
 
-#### Updating pre-assigned role [PUT]
+- Request Updating pre-assigned role (application/json)
 
-    - A Space Admin-only action
-
-- Request (application/json)
+    Must be performed by Space Admin.
 
     - Attributes (object)
 


### PR DESCRIPTION
Action cannot be documented twice.  It's invalid.  Provide multiple examples do describe how it works in various contexts. Fixes #37.

Validations do pass. But unfortunately, I was unable to check how HTML documentation looks like. [Docprint](https://github.com/swathysubhash/docprint) failed to generate expected output, but this tool may be simply buggy or feature-incomplete. I don't know what tool is used by Apiary.

@ribose-jeffreylau, please merge if you believe it's fine.